### PR TITLE
Add 'full name' reflection + fix some reflection bugs

### DIFF
--- a/src/sgl/device/python/reflection.cpp
+++ b/src/sgl/device/python/reflection.cpp
@@ -96,6 +96,7 @@ SGL_PY_EXPORT(device_reflection)
     type_reflection //
         .def_prop_ro("kind", &TypeReflection::kind, D(TypeReflection, kind))
         .def_prop_ro("name", &TypeReflection::name, D(TypeReflection, name))
+        .def_prop_ro("full_name", &TypeReflection::full_name, D_NA(TypeReflection, full_name))
         .def_prop_ro("fields", &TypeReflection::fields, D(TypeReflection, fields))
         .def_prop_ro("element_count", &TypeReflection::element_count, D(TypeReflection, element_count))
         .def_prop_ro("element_type", &TypeReflection::element_type, D(TypeReflection, element_type))

--- a/src/sgl/device/reflection.cpp
+++ b/src/sgl/device/reflection.cpp
@@ -15,40 +15,32 @@ namespace sgl {
 
 namespace detail {
 
-    ref<const DeclReflection> from_slang(ref<const Object> owner, slang::DeclReflection* decl_reflection)
+    template<typename SGLType, typename SlangType>
+    ref<const SGLType> create_reflection_type_from_slang_type(ref<const Object> owner, SlangType* decl_reflection)
     {
-        return make_ref<const DeclReflection>(std::move(owner), decl_reflection);
+        if (decl_reflection)
+            return make_ref<const SGLType>(std::move(owner), decl_reflection);
+        else
+            return nullptr;
     }
-    ref<const TypeReflection> from_slang(ref<const Object> owner, slang::TypeReflection* type_reflection)
-    {
-        return make_ref<const TypeReflection>(std::move(owner), type_reflection);
+
+#define SGL_FROM_SLANG(type_name)                                                                                      \
+    ref<const type_name> from_slang(ref<const Object> owner, slang::type_name* decl_reflection)                        \
+    {                                                                                                                  \
+        return create_reflection_type_from_slang_type<type_name, slang::type_name>(owner, decl_reflection);            \
     }
-    ref<const TypeLayoutReflection>
-    from_slang(ref<const Object> owner, slang::TypeLayoutReflection* type_layout_reflection)
-    {
-        return make_ref<const TypeLayoutReflection>(std::move(owner), type_layout_reflection);
-    }
-    ref<const FunctionReflection> from_slang(ref<const Object> owner, slang::FunctionReflection* variable_reflection)
-    {
-        return make_ref<const FunctionReflection>(std::move(owner), variable_reflection);
-    }
-    ref<const VariableReflection> from_slang(ref<const Object> owner, slang::VariableReflection* variable_reflection)
-    {
-        return make_ref<const VariableReflection>(std::move(owner), variable_reflection);
-    }
-    ref<const VariableLayoutReflection>
-    from_slang(ref<const Object> owner, slang::VariableLayoutReflection* variable_layout_reflection)
-    {
-        return make_ref<const VariableLayoutReflection>(std::move(owner), variable_layout_reflection);
-    }
-    ref<const EntryPointLayout> from_slang(ref<const Object> owner, slang::EntryPointLayout* entry_point_reflection)
-    {
-        return make_ref<const EntryPointLayout>(std::move(owner), entry_point_reflection);
-    }
-    ref<const ProgramLayout> from_slang(ref<const Object> owner, slang::ProgramLayout* program_layout)
-    {
-        return make_ref<const ProgramLayout>(std::move(owner), program_layout);
-    }
+
+    SGL_FROM_SLANG(DeclReflection);
+    SGL_FROM_SLANG(TypeReflection);
+    SGL_FROM_SLANG(TypeLayoutReflection);
+    SGL_FROM_SLANG(FunctionReflection);
+    SGL_FROM_SLANG(VariableReflection);
+    SGL_FROM_SLANG(VariableLayoutReflection);
+    SGL_FROM_SLANG(EntryPointLayout);
+    SGL_FROM_SLANG(ProgramLayout);
+
+#undef SGL_FROM_SLANG
+
 } // namespace detail
 
 std::string c_str_to_string(const char* str)
@@ -146,6 +138,13 @@ ref<const DeclReflection> DeclReflection::find_first_child_of_kind(Kind kind, st
         }
     }
     return nullptr;
+}
+
+std::string TypeReflection::full_name() const
+{
+    Slang::ComPtr<ISlangBlob> blob;
+    m_target->getFullName(blob.writeRef());
+    return std::string((const char*)blob->getBufferPointer());
 }
 
 TypeReflectionFieldList TypeReflection::fields() const

--- a/src/sgl/device/reflection.cpp
+++ b/src/sgl/device/reflection.cpp
@@ -16,18 +16,18 @@ namespace sgl {
 namespace detail {
 
     template<typename SGLType, typename SlangType>
-    ref<const SGLType> create_reflection_type_from_slang_type(ref<const Object> owner, SlangType* decl_reflection)
+    ref<const SGLType> create_reflection_type_from_slang_type(ref<const Object> owner, SlangType* slang_reflection)
     {
-        if (decl_reflection)
-            return make_ref<const SGLType>(std::move(owner), decl_reflection);
+        if (slang_reflection)
+            return make_ref<const SGLType>(std::move(owner), slang_reflection);
         else
             return nullptr;
     }
 
 #define SGL_FROM_SLANG(type_name)                                                                                      \
-    ref<const type_name> from_slang(ref<const Object> owner, slang::type_name* decl_reflection)                        \
+    ref<const type_name> from_slang(ref<const Object> owner, slang::type_name* slang_reflection)                       \
     {                                                                                                                  \
-        return create_reflection_type_from_slang_type<type_name, slang::type_name>(owner, decl_reflection);            \
+        return create_reflection_type_from_slang_type<type_name, slang::type_name>(owner, slang_reflection);           \
     }
 
     SGL_FROM_SLANG(DeclReflection);

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -529,6 +529,8 @@ public:
 
     char const* name() const { return m_target->getName(); }
 
+    std::string full_name() const;
+
     bool is_struct() const { return kind() == Kind::struct_; }
 
     uint32_t field_count() const

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -693,7 +693,11 @@ public:
 
     TypeLayoutReflectionFieldList fields() const;
 
-    bool is_array() const { return type()->is_array(); }
+    bool is_array() const
+    {
+        auto t = type();
+        return t ? t->is_array() : false;
+    }
 
     ref<const TypeLayoutReflection> unwrap_array() const
     {
@@ -704,7 +708,7 @@ public:
         return type_layout;
     }
 
-    size_t element_count() const { return type()->element_count(); }
+    size_t element_count() const { return m_target->getElementCount(); }
 
     size_t element_stride(TypeReflection::ParameterCategory category = TypeReflection::ParameterCategory::uniform) const
     {

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -693,11 +693,7 @@ public:
 
     TypeLayoutReflectionFieldList fields() const;
 
-    bool is_array() const
-    {
-        auto t = type();
-        return t ? t->is_array() : false;
-    }
+    bool is_array() const { return kind() == TypeReflection::Kind::array; }
 
     ref<const TypeLayoutReflection> unwrap_array() const
     {

--- a/src/sgl/device/tests/test_reflection.py
+++ b/src/sgl/device/tests/test_reflection.py
@@ -439,7 +439,6 @@ def test_full_type_name(test_id: str, device_type: sgl.DeviceType):
     """,
     )
 
-    # Get and read on 1 line.
     struct_a_decl = module.module_decl.find_first_child_of_kind(
         sgl.DeclReflection.Kind.struct, "A"
     )
@@ -458,7 +457,6 @@ def test_full_type_name(test_id: str, device_type: sgl.DeviceType):
     )
     scalar_types = scalar_types_decl.as_type()
     names = [(x.type.name, x.type.full_name, x.name) for x in scalar_types.fields]
-    pprint(names)
 
     expected = [
         ("bool", "bool", "bool_var"),
@@ -487,7 +485,6 @@ def test_full_type_name(test_id: str, device_type: sgl.DeviceType):
     )
     vector_types = vector_types_decl.as_type()
     names = [(x.type.name, x.type.full_name, x.name) for x in vector_types.fields]
-    pprint(names)
 
     expected = [
         ("vector", "vector<float,3>", "vec_float_3_var"),
@@ -496,6 +493,28 @@ def test_full_type_name(test_id: str, device_type: sgl.DeviceType):
     ]
 
     assert names == expected
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_null_type(test_id: str, device_type: sgl.DeviceType):
+    device = helpers.get_device(type=device_type)
+
+    # Create a session, and within it a module.
+    session = helpers.create_session(device, {})
+    module = session.load_module_from_source(
+        module_name=f"module_from_source_{test_id}",
+        source="""
+        struct A {
+            float a_val;
+        };
+        uniform A myglobal;
+    """,
+    )
+
+    globals_layout = module.layout.globals_type_layout
+    globals_type_layout = globals_layout.element_type_layout
+    invalid_element_type_layout = globals_type_layout.element_type_layout
+    assert invalid_element_type_layout is None
 
 
 if __name__ == "__main__":

--- a/src/sgl/device/tests/test_reflection.py
+++ b/src/sgl/device/tests/test_reflection.py
@@ -517,4 +517,4 @@ def test_null_type(test_id: str, device_type: sgl.DeviceType):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v", "-s"])
+    pytest.main([__file__, "-v"])

--- a/src/sgl/device/tests/test_reflection.py
+++ b/src/sgl/device/tests/test_reflection.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from pprint import pprint
 import pytest
 import sys
 import sgl


### PR DESCRIPTION
- Added reflection of type 'full name' property (returns, eg, vector<float,4> instead of vector)
- Added extra tests to verify full name + modifiers work correctly
- Fixed issue + wrote tests for converting a null return value from slang into an 'empty' container instead of a null container
