### PR TITLE
avoid using CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0077 NEW)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(utils)
 
 set(VCPKG_INSTALL_OPTIONS "--no-print-usage" "--allow-unsupported")
@@ -373,15 +373,15 @@ add_dependencies(sgl copy_binary_files)
 
 # Generate setpath scripts.
 if(SGL_WINDOWS)
-    file(GENERATE OUTPUT ${SGL_OUTPUT_DIRECTORY}/setpath.bat INPUT ${CMAKE_SOURCE_DIR}/resources/setpath.bat.in)
-    file(GENERATE OUTPUT ${SGL_OUTPUT_DIRECTORY}/setpath.ps1 INPUT ${CMAKE_SOURCE_DIR}/resources/setpath.ps1.in)
+    file(GENERATE OUTPUT ${SGL_OUTPUT_DIRECTORY}/setpath.bat INPUT ${CMAKE_CURRENT_SOURCE_DIR}/resources/setpath.bat.in)
+    file(GENERATE OUTPUT ${SGL_OUTPUT_DIRECTORY}/setpath.ps1 INPUT ${CMAKE_CURRENT_SOURCE_DIR}/resources/setpath.ps1.in)
 endif()
 
 if(SGL_LINUX OR SGL_MACOS)
-    file(GENERATE OUTPUT ${SGL_OUTPUT_DIRECTORY}/setpath.sh INPUT ${CMAKE_SOURCE_DIR}/resources/setpath.sh.in)
+    file(GENERATE OUTPUT ${SGL_OUTPUT_DIRECTORY}/setpath.sh INPUT ${CMAKE_CURRENT_SOURCE_DIR}/resources/setpath.sh.in)
 endif()
 
-file(GENERATE OUTPUT ${SGL_OUTPUT_DIRECTORY}/python/sgl/__init__.py INPUT ${CMAKE_SOURCE_DIR}/resources/__init__.py)
+file(GENERATE OUTPUT ${SGL_OUTPUT_DIRECTORY}/python/sgl/__init__.py INPUT ${CMAKE_CURRENT_SOURCE_DIR}/resources/__init__.py)
 
 # -----------------------------------------------------------------------------
 # install
@@ -402,5 +402,7 @@ install(
 )
 
 # Install python extension.
+if(SGL_BUILD_PYTHON)
 install(TARGETS sgl_ext LIBRARY DESTINATION sgl)
 install(DIRECTORY ${SGL_OUTPUT_DIRECTORY}/python/sgl/ DESTINATION sgl FILES_MATCHING PATTERN "*.py" PATTERN "*.pyi")
+endif()

--- a/cmake/git_version.cmake
+++ b/cmake/git_version.cmake
@@ -95,7 +95,7 @@ function(git_version_setup)
     set_target_properties(git_version_run_check PROPERTIES FOLDER "misc")
 
     add_library(git_version INTERFACE)
-    target_include_directories(git_version INTERFACE ${CMAKE_BINARY_DIR}/git_version)
+    target_include_directories(git_version INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/git_version)
     add_dependencies(git_version git_version_run_check)
 
     git_version_check()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -447,7 +447,7 @@ if(SGL_BUILD_PYTHON)
         add_custom_command(
             APPEND
             OUTPUT ${stub_file}
-            COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/postprocess_stub.py --file=${stub_file} --quiet
+            COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/postprocess_stub.py --file=${stub_file} --quiet
             COMMENT "Post-processing stub ${stub_file}"
         )
     endfunction()


### PR DESCRIPTION
this is the first step towards allowing sgl to be used from parent cmake projects uging `add_subdirectory`