### PR TITLE
Exposed more of slang reflection api

### DIFF
--- a/src/sgl/device/python/reflection.cpp
+++ b/src/sgl/device/python/reflection.cpp
@@ -179,6 +179,8 @@ SGL_PY_EXPORT(device_reflection)
 
     nb::class_<ProgramLayout, BaseReflectionObject> program_layout(m, "ProgramLayout", D(ProgramLayout));
 
+    nb::sgl_enum<ProgramLayout::LayoutRules>(program_layout, "LayoutRules", D_NA(ProgramLayout, LayoutRules));
+
     nb::class_<ProgramLayout::HashedString>(program_layout, "HashedString", D(ProgramLayout, HashedString))
         .def_ro("string", &ProgramLayout::HashedString::string, D(ProgramLayout, HashedString, string))
         .def_ro("hash", &ProgramLayout::HashedString::hash, D(ProgramLayout, HashedString, hash));
@@ -192,6 +194,27 @@ SGL_PY_EXPORT(device_reflection)
         )
         .def_prop_ro("parameters", &ProgramLayout::parameters, D(ProgramLayout, parameters))
         .def_prop_ro("entry_points", &ProgramLayout::entry_points, D(ProgramLayout, entry_points))
+        .def("find_type_by_name", &ProgramLayout::find_type_by_name, "name"_a, D_NA(ProgramLayout, find_type_by_name))
+        .def(
+            "find_function_by_name",
+            &ProgramLayout::find_function_by_name,
+            "name"_a,
+            D_NA(ProgramLayout, find_function_by_name)
+        )
+        .def(
+            "find_function_by_name_in_type",
+            &ProgramLayout::find_function_by_name_in_type,
+            "type"_a,
+            "name"_a,
+            D_NA(ProgramLayout, find_function_by_name_in_type)
+        )
+        .def(
+            "get_type_layout",
+            &ProgramLayout::get_type_layout,
+            "type"_a,
+            "rules"_a = ProgramLayout::LayoutRules::default_,
+            D_NA(ProgramLayout, get_type_layout)
+        )
         .def_prop_ro("hashed_strings", &ProgramLayout::hashed_strings, D(ProgramLayout, hashed_strings))
         .def("__repr__", &ProgramLayout::to_string);
 

--- a/src/sgl/device/python/reflection.cpp
+++ b/src/sgl/device/python/reflection.cpp
@@ -179,8 +179,6 @@ SGL_PY_EXPORT(device_reflection)
 
     nb::class_<ProgramLayout, BaseReflectionObject> program_layout(m, "ProgramLayout", D(ProgramLayout));
 
-    nb::sgl_enum<ProgramLayout::LayoutRules>(program_layout, "LayoutRules", D_NA(ProgramLayout, LayoutRules));
-
     nb::class_<ProgramLayout::HashedString>(program_layout, "HashedString", D(ProgramLayout, HashedString))
         .def_ro("string", &ProgramLayout::HashedString::string, D(ProgramLayout, HashedString, string))
         .def_ro("hash", &ProgramLayout::HashedString::hash, D(ProgramLayout, HashedString, hash));
@@ -208,13 +206,7 @@ SGL_PY_EXPORT(device_reflection)
             "name"_a,
             D_NA(ProgramLayout, find_function_by_name_in_type)
         )
-        .def(
-            "get_type_layout",
-            &ProgramLayout::get_type_layout,
-            "type"_a,
-            "rules"_a = ProgramLayout::LayoutRules::default_,
-            D_NA(ProgramLayout, get_type_layout)
-        )
+        .def("get_type_layout", &ProgramLayout::get_type_layout, "type"_a, D_NA(ProgramLayout, get_type_layout))
         .def_prop_ro("hashed_strings", &ProgramLayout::hashed_strings, D(ProgramLayout, hashed_strings))
         .def("__repr__", &ProgramLayout::to_string);
 

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -937,8 +937,8 @@ public:
     }
 
     enum class LayoutRules {
-        default_ = slang::LayoutRules::Default,
-        metal_argument_buffer_tier2 = slang::LayoutRules::MetalArgumentBufferTier2
+        default_ = SLANG_LAYOUT_RULES_DEFAULT,
+        metal_argument_buffer_tier2 = SLANG_LAYOUT_RULES_METAL_ARGUMENT_BUFFER_TIER_2
     };
     SGL_ENUM_INFO(
         LayoutRules,

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -936,18 +936,6 @@ public:
         return detail::from_slang(owner, program_layout);
     }
 
-    enum class LayoutRules {
-        default_ = SLANG_LAYOUT_RULES_DEFAULT,
-        metal_argument_buffer_tier2 = SLANG_LAYOUT_RULES_METAL_ARGUMENT_BUFFER_TIER_2
-    };
-    SGL_ENUM_INFO(
-        LayoutRules,
-        {
-            {LayoutRules::default_, "default"},
-            {LayoutRules::metal_argument_buffer_tier2, "metal_argument_buffer_tier2"},
-        }
-    );
-
     ProgramLayout(ref<const Object> owner, slang::ProgramLayout* target)
         : BaseReflectionObjectImpl(std::move(owner), target)
     {
@@ -1032,12 +1020,10 @@ public:
     }
 
     /// Get corresponding type layout from a given type.
-    ref<const TypeLayoutReflection> get_type_layout(TypeReflection* type, LayoutRules rules = LayoutRules::default_)
+    ref<const TypeLayoutReflection> get_type_layout(TypeReflection* type)
     {
-        return detail::from_slang(
-            m_owner,
-            m_target->getTypeLayout(type->slang_target(), static_cast<slang::LayoutRules>(rules))
-        );
+        // TODO: Once device is available via session reference, pass metal layout rules for metal target
+        return detail::from_slang(m_owner, m_target->getTypeLayout(type->slang_target(), slang::LayoutRules::Default));
     }
 
     uint32_t hashed_string_count() const { return narrow_cast<uint32_t>(m_target->getHashedStringCount()); }
@@ -1080,7 +1066,6 @@ public:
 
     std::string to_string() const;
 };
-SGL_ENUM_REGISTER(ProgramLayout::LayoutRules);
 
 /// ProgramLayout lazy parameter list evaluation.
 class SGL_API ProgramLayoutParameterList : public BaseReflectionList<ProgramLayout, VariableLayoutReflection> {

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -1031,6 +1031,7 @@ public:
         return detail::from_slang(m_owner, m_target->findFunctionByNameInType(type->slang_target(), name));
     }
 
+    /// Get corresponding type layout from a given type.
     ref<const TypeLayoutReflection> get_type_layout(TypeReflection* type, LayoutRules rules = LayoutRules::default_)
     {
         return detail::from_slang(m_owner, m_target->getTypeLayout(type->slang_target(), (slang::LayoutRules)rules));

--- a/src/sgl/device/reflection.h
+++ b/src/sgl/device/reflection.h
@@ -1034,7 +1034,10 @@ public:
     /// Get corresponding type layout from a given type.
     ref<const TypeLayoutReflection> get_type_layout(TypeReflection* type, LayoutRules rules = LayoutRules::default_)
     {
-        return detail::from_slang(m_owner, m_target->getTypeLayout(type->slang_target(), (slang::LayoutRules)rules));
+        return detail::from_slang(
+            m_owner,
+            m_target->getTypeLayout(type->slang_target(), static_cast<slang::LayoutRules>(rules))
+        );
     }
 
     uint32_t hashed_string_count() const { return narrow_cast<uint32_t>(m_target->getHashedStringCount()); }

--- a/src/sgl/device/tests/test_reflection.py
+++ b/src/sgl/device/tests/test_reflection.py
@@ -570,5 +570,76 @@ def test_deduplication(test_id: str, device_type: sgl.DeviceType):
         assert p is p_again
 
 
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_find_type_by_name(test_id: str, device_type: sgl.DeviceType):
+    device = helpers.get_device(type=device_type)
+
+    # Create a session, and within it a module.
+    session = helpers.create_session(device, {})
+    module = session.load_module_from_source(
+        module_name=f"module_from_source_{test_id}",
+        source="""
+        struct Hello {
+            int a;
+            void func2() {}
+        }
+    """,
+    )
+
+    # Get and read on 1 line.
+    t = module.layout.find_type_by_name("Hello")
+    assert t is not None
+    assert t.name == "Hello"
+    f2 = module.layout.find_function_by_name_in_type(t, "func2")
+    assert f2 is not None
+    assert f2.name == "func2"
+
+
+@pytest.mark.skip("Pending slang fix.")
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_find_func_by_name(test_id: str, device_type: sgl.DeviceType):
+    device = helpers.get_device(type=device_type)
+
+    # Create a session, and within it a module.
+    session = helpers.create_session(device, {})
+    module = session.load_module_from_source(
+        module_name=f"module_from_source_{test_id}",
+        source="""
+        void func() {}
+    """,
+    )
+
+    # Get and read on 1 line.
+    f1 = module.layout.find_function_by_name("func")
+    assert f1 is not None
+    assert f1.name == "func"
+
+
+@pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
+def test_get_type_layout(test_id: str, device_type: sgl.DeviceType):
+    device = helpers.get_device(type=device_type)
+
+    # Create a session, and within it a module.
+    session = helpers.create_session(device, {})
+    module = session.load_module_from_source(
+        module_name=f"module_from_source_{test_id}",
+        source="""
+        struct Hello {
+            int a;
+            void func2() {}
+        }
+        void func() {}
+    """,
+    )
+
+    # Get and read on 1 line.
+    t = module.layout.find_type_by_name("Hello")
+    assert t is not None
+    assert t.name == "Hello"
+    tl = module.layout.get_type_layout(t)
+    assert tl is not None
+    assert tl.name == "Hello"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/sgl/device/tests/test_reflection.py
+++ b/src/sgl/device/tests/test_reflection.py
@@ -620,7 +620,6 @@ def test_find_generic_type_by_name(test_id: str, device_type: sgl.DeviceType):
     assert a.type.name == "int"
 
 
-@pytest.mark.skip("Pending bug fix for slang find function by name")
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_find_func_by_name(test_id: str, device_type: sgl.DeviceType):
     device = helpers.get_device(type=device_type)
@@ -630,7 +629,7 @@ def test_find_func_by_name(test_id: str, device_type: sgl.DeviceType):
     module = session.load_module_from_source(
         module_name=f"module_from_source_{test_id}",
         source=r"""
-        int func()
+        int test()
         {
             return 0;
         }
@@ -638,9 +637,9 @@ def test_find_func_by_name(test_id: str, device_type: sgl.DeviceType):
     )
 
     # Find and verify the function.
-    f1 = module.layout.find_function_by_name("func")
+    f1 = module.layout.find_function_by_name("test")
     assert f1 is not None
-    assert f1.name == "func"
+    assert f1.name == "test"
 
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
@@ -656,7 +655,7 @@ def test_get_type_layout(test_id: str, device_type: sgl.DeviceType):
             int a;
             void func2() {}
         }
-        void func() {}
+        void test() {}
     """,
     )
 

--- a/src/sgl/device/tests/test_reflection.py
+++ b/src/sgl/device/tests/test_reflection.py
@@ -620,6 +620,7 @@ def test_find_generic_type_by_name(test_id: str, device_type: sgl.DeviceType):
     assert a.type.name == "int"
 
 
+@pytest.mark.skip("Pending bug fix for slang find function by name")
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_find_func_by_name(test_id: str, device_type: sgl.DeviceType):
     device = helpers.get_device(type=device_type)
@@ -659,13 +660,14 @@ def test_get_type_layout(test_id: str, device_type: sgl.DeviceType):
     """,
     )
 
-    # Get and read on 1 line.
+    # Get type and convert to type layout.
     t = module.layout.find_type_by_name("Hello")
     assert t is not None
     assert t.name == "Hello"
     tl = module.layout.get_type_layout(t)
     assert tl is not None
     assert tl.name == "Hello"
+    assert tl.size == 4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Exposed some of the 'find x' functions on program layout, which resolve specialized generic types if generic variables are defined. 
- getTypeLayout exposed, so python app can get from type reflection -> type layout and then allocate a buffer with it
