### PR TITLE
Share cursor code + use for kernel dispatch

### DIFF
--- a/src/sgl/device/python/cursor_utils.h
+++ b/src/sgl/device/python/cursor_utils.h
@@ -472,18 +472,6 @@ private:
         self._set_vector(nbarray.data(), nbarray.nbytes(), TypeReflection::ScalarType::bool_, ValType::dimension);
     }
 
-    /// Use specialization for each bool type
-#define bool_vector_case(c_type)                                                                                       \
-    template<>                                                                                                         \
-    inline void _write_vector_from_numpy<c_type>(CursorType & self, nb::ndarray<nb::numpy> nbarray)                    \
-    {                                                                                                                  \
-        _write_bool_vector_from_numpy<c_type>(self, nbarray);                                                          \
-    }
-    bool_vector_case(bool1);
-    bool_vector_case(bool2);
-    bool_vector_case(bool3);
-    bool_vector_case(bool4);
-
     /// Write vector value to buffer element cursor from Python object
     template<typename ValType>
         requires IsSpecializationOfVector<ValType>
@@ -536,6 +524,39 @@ private:
         }
     }
 };
+
+
+template<typename CursorType>
+template<>
+inline void
+WriteConverterTable<CursorType>::_write_vector_from_numpy<bool1>(CursorType& self, nb::ndarray<nb::numpy> nbarray)
+{
+    _write_bool_vector_from_numpy<bool1>(self, nbarray);
+}
+
+template<typename CursorType>
+template<>
+inline void
+WriteConverterTable<CursorType>::_write_vector_from_numpy<bool2>(CursorType& self, nb::ndarray<nb::numpy> nbarray)
+{
+    _write_bool_vector_from_numpy<bool1>(self, nbarray);
+}
+
+template<typename CursorType>
+template<>
+inline void
+WriteConverterTable<CursorType>::_write_vector_from_numpy<bool3>(CursorType& self, nb::ndarray<nb::numpy> nbarray)
+{
+    _write_bool_vector_from_numpy<bool1>(self, nbarray);
+}
+
+template<typename CursorType>
+template<>
+inline void
+WriteConverterTable<CursorType>::_write_vector_from_numpy<bool4>(CursorType& self, nb::ndarray<nb::numpy> nbarray)
+{
+    _write_bool_vector_from_numpy<bool1>(self, nbarray);
+}
 
 #undef scalar_case
 #undef vector_case

--- a/src/sgl/device/python/cursor_utils.h
+++ b/src/sgl/device/python/cursor_utils.h
@@ -88,13 +88,7 @@ public:
     ReadConverterTable()
     {
         // Initialize all entries to an error function that throws an exception.
-        auto read_err_func = [](const CursorType&)
-        {
-            if (true) { // avoid 'unreachable code' warnings
-                SGL_THROW("Unsupported element type");
-            }
-            return nb::none();
-        };
+        auto read_err_func = [](const CursorType&) -> nb::object { SGL_THROW("Unsupported element type"); };
         for (int i = 0; i < (int)TypeReflection::ScalarType::COUNT; i++) {
             m_read_scalar[i] = read_err_func;
             for (int j = 0; j < 5; ++j) {
@@ -159,7 +153,7 @@ public:
         m_stack.clear();
         try {
             return read_internal(self);
-        } catch (std::exception err) {
+        } catch (const std::exception& err) {
             SGL_THROW("{}: {}", build_error(), err.what());
         }
     }
@@ -345,7 +339,7 @@ public:
         m_stack.clear();
         try {
             write_internal(self, nbval);
-        } catch (std::exception err) {
+        } catch (const std::exception& err) {
             SGL_THROW("{}: {}", build_error(), err.what());
         }
     }

--- a/src/sgl/device/python/kernel.cpp
+++ b/src/sgl/device/python/kernel.cpp
@@ -11,57 +11,11 @@
 
 namespace sgl {
 
+extern void write_shader_cursor(ShaderCursor& cursor, nb::object value);
+
 inline void bind_python_var(ShaderCursor cursor, nb::handle var)
 {
-#define HANDLE_VECTOR_TYPE(type)                                                                                       \
-    if (nb::isinstance<type>(var)) {                                                                                   \
-        cursor = nb::cast<type>(var);                                                                                  \
-        return;                                                                                                        \
-    }
-
-    HANDLE_VECTOR_TYPE(uint2);
-    HANDLE_VECTOR_TYPE(uint3);
-    HANDLE_VECTOR_TYPE(uint4);
-    HANDLE_VECTOR_TYPE(bool2);
-    HANDLE_VECTOR_TYPE(bool3);
-    HANDLE_VECTOR_TYPE(bool4);
-    HANDLE_VECTOR_TYPE(int2);
-    HANDLE_VECTOR_TYPE(int3);
-    HANDLE_VECTOR_TYPE(int4);
-    HANDLE_VECTOR_TYPE(float2);
-    HANDLE_VECTOR_TYPE(float3);
-    HANDLE_VECTOR_TYPE(float4);
-
-#undef HANDLE_VECTOR_TYPE
-
-    if (nb::isinstance<nb::int_>(var)) {
-        cursor = nb::cast<int>(var);
-    } else if (nb::isinstance<nb::float_>(var)) {
-        cursor = nb::cast<float>(var);
-    } else if (nb::isinstance<ResourceView>(var)) {
-        cursor = ref<ResourceView>(nb::cast<ResourceView*>(var));
-    } else if (nb::isinstance<Buffer>(var)) {
-        cursor = ref<Buffer>(nb::cast<Buffer*>(var));
-    } else if (nb::isinstance<Texture>(var)) {
-        cursor = ref<Texture>(nb::cast<Texture*>(var));
-    } else if (nb::isinstance<Sampler>(var)) {
-        cursor = ref<Sampler>(nb::cast<Sampler*>(var));
-    } else if (nb::isinstance<AccelerationStructure>(var)) {
-        cursor = ref<AccelerationStructure>(nb::cast<AccelerationStructure*>(var));
-    } else if (nb::isinstance<MutableShaderObject>(var)) {
-        cursor = ref<MutableShaderObject>(nb::cast<MutableShaderObject*>(var));
-    } else if (nb::isinstance<nb::list>(var)) {
-        uint32_t index = 0;
-        for (const auto& value : nb::cast<nb::list>(var))
-            bind_python_var(cursor[index++], value);
-    } else if (nb::isinstance<nb::dict>(var)) {
-        for (const auto& [key, value] : nb::cast<nb::dict>(var))
-            bind_python_var(cursor[nb::cast<std::string_view>(key)], value);
-    } else if (nb::isinstance<nb::ndarray<nb::device::cuda>>(var)) {
-        cursor.set_cuda_tensor_view(ndarray_to_cuda_tensor_view(nb::cast<nb::ndarray<nb::device::cuda>>(var)));
-    } else {
-        SGL_THROW("Unsupported variable type!");
-    }
+    write_shader_cursor(cursor, nb::cast<nb::object>(var));
 }
 
 } // namespace sgl

--- a/src/sgl/device/python/shader_cursor.cpp
+++ b/src/sgl/device/python/shader_cursor.cpp
@@ -68,6 +68,12 @@ namespace detail {
 
     static ShaderCursorWriteConverterTable _writeconv;
 } // namespace detail
+
+void write_shader_cursor(ShaderCursor& cursor, nb::object value)
+{
+    detail::_writeconv.write(cursor, value);
+}
+
 } // namespace sgl
 
 SGL_PY_EXPORT(device_shader_cursor)

--- a/src/sgl/device/python/shader_cursor.cpp
+++ b/src/sgl/device/python/shader_cursor.cpp
@@ -11,6 +11,12 @@
 
 #include "sgl/device/python/cursor_utils.h"
 
+namespace sgl {
+namespace detail {
+    static WriteConverterTable<ShaderCursor> _writeconv;
+} // namespace detail
+} // namespace sgl
+
 SGL_PY_EXPORT(device_shader_cursor)
 {
     using namespace sgl;
@@ -51,8 +57,6 @@ SGL_PY_EXPORT(device_shader_cursor)
         );
 
     bind_traversable_cursor(shader_cursor);
-    bind_writable_cursor_basic_types(shader_cursor);
-
 #define def_setter(type)                                                                                               \
     shader_cursor.def(                                                                                                 \
         "__setitem__",                                                                                                 \
@@ -78,4 +82,6 @@ SGL_PY_EXPORT(device_shader_cursor)
     shader_cursor.def("__setitem__", set_cuda_tensor_field);
     shader_cursor.def("__setitem__", set_cuda_tensor_element);
     shader_cursor.def("__setattr__", set_cuda_tensor_field);
+
+    bind_writable_cursor(detail::_writeconv, shader_cursor);
 }

--- a/src/sgl/device/shader_cursor.cpp
+++ b/src/sgl/device/shader_cursor.cpp
@@ -579,6 +579,13 @@ SET_VECTOR(uint2, uint32);
 SET_VECTOR(uint3, uint32);
 SET_VECTOR(uint4, uint32);
 
+// MACOS treats these as separate types to int/uint, so they need to be
+// provided as extra overloads for linking to succeed.
+#if SGL_MACOS
+SET_SCALAR(long, int32);
+SET_SCALAR(unsigned long, uint32);
+#endif
+
 SET_SCALAR(int64_t, int64);
 SET_SCALAR(uint64_t, uint64);
 


### PR DESCRIPTION
Shader cursor, buffer cursor and compute kernel all share same more flexible implementation of Python api.
Added lightweight name stack so errors can report the field names causing problems.

Call from kernel.cpp -> shader_cursor.cpp uses externed function which is a bit dirty, but avoids adding extra include files etc for the sake of 1 call. Undecided on this one.
