### PR TITLE
Fix issue where shaders in cwd are reported without absolute path.

### DIFF
--- a/src/sgl/device/hot_reload.cpp
+++ b/src/sgl/device/hot_reload.cpp
@@ -101,11 +101,9 @@ void HotReload::update_watched_paths_for_session(SlangSession* session)
                     std::filesystem::path abs_path = path;
                     if (!abs_path.is_absolute()) {
                         // IModule::getDependencyFilePath can return relative file paths for shaders
-                        // that are in the current working directory, as reported in
-                        // https://github.com/shader-slang/slang/issues/5332
-                        // We look for ./abs_path if the path is not absolute, to determine if the string
-                        // references a file in cwd, or a string based module.
-                        abs_path = "." / abs_path;
+                        // that are in the current working directory.
+                        // If the path is not absolute, we also try to resolve it against cwd to turn it into
+                        // absolute path. The returned path can also be a non-file, e.g. for string modules.
                         if (!std::filesystem::exists(abs_path))
                             continue;
                         abs_path = std::filesystem::absolute(abs_path);

--- a/src/sgl/device/hot_reload.cpp
+++ b/src/sgl/device/hot_reload.cpp
@@ -98,9 +98,17 @@ void HotReload::update_watched_paths_for_session(SlangSession* session)
                 // Get the dependency as an FS path, verify it is absolute and turn into directory path.
                 const char* path = slang_module->getDependencyFilePath(dependency_index);
                 if (path) {
-                    std::filesystem::path abs_path = slang_module->getDependencyFilePath(dependency_index);
+                    std::filesystem::path abs_path = path;
                     if (!abs_path.is_absolute()) {
-                        continue;
+                        // IModule::getDependencyFilePath can return relative file paths for shaders
+                        // that are in the current working directory, as reported in
+                        // https://github.com/shader-slang/slang/issues/5332
+                        // We look for ./abs_path if the path is not absolute, to determine if the string
+                        // references a file in cwd, or a string based module.
+                        abs_path = "." / abs_path;
+                        if (!std::filesystem::exists(abs_path))
+                            continue;
+                        abs_path = std::filesystem::absolute(abs_path);
                     }
                     abs_path = abs_path.parent_path().make_preferred();
 


### PR DESCRIPTION
This is work around for issue https://github.com/shader-slang/slang/issues/5332 where Slang reports file dependencies in cwd with relative rather than absolute paths.