### PR TITLE
Support weak references + close event for device

### DIFF
--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -550,10 +550,17 @@ void Device::close()
 
     wait();
 
+    // Handle device close callbacks
+    for (const DeviceCloseCallback& callback : m_device_close_callbacks)
+        callback(this);
+
     // Make sure Device's ref count is not going to zero when releasing resources.
     inc_ref();
 
     m_closed = true;
+
+    m_shader_hot_reload_callbacks.clear();
+    m_device_close_callbacks.clear();
 
     m_blitter.reset();
     m_debug_printer.reset();

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -178,6 +178,9 @@ struct ShaderCacheStats {
 struct ShaderHotReloadEvent { };
 using ShaderHotReloadCallback = std::function<void(const ShaderHotReloadEvent&)>;
 
+
+using DeviceCloseCallback = std::function<void(Device*)>;
+
 class SGL_API Device : public Object {
     SGL_OBJECT(Device)
 public:
@@ -576,6 +579,12 @@ public:
         m_shader_hot_reload_callbacks.push_back(call_back);
     }
 
+    /// Register a device close callback, called at start of device close.
+    void register_device_close_callback(DeviceCloseCallback call_back)
+    {
+        m_device_close_callbacks.push_back(call_back);
+    }
+
     cuda::Device* cuda_device() const { return m_cuda_device.get(); }
 
     std::string to_string() const override;
@@ -632,6 +641,9 @@ private:
 
     /// List of callbacks for hot reload event
     std::vector<ShaderHotReloadCallback> m_shader_hot_reload_callbacks;
+
+    /// List of callbacks for shutdown event
+    std::vector<DeviceCloseCallback> m_device_close_callbacks;
 
     struct DeferredRelease {
         uint64_t fence_value;

--- a/src/sgl/device/python/device.cpp
+++ b/src/sgl/device/python/device.cpp
@@ -147,7 +147,7 @@ SGL_PY_EXPORT(device_device)
 
     nb::class_<ShaderHotReloadEvent>(m, "ShaderHotReloadEvent", D_NA(ShaderHotReloadEvent));
 
-    nb::class_<Device, Object> device(m, "Device", D(Device));
+    nb::class_<Device, Object> device(m, "Device", nb::is_weak_referenceable(), D(Device));
     device.def(
         "__init__",
         [](Device* self,
@@ -758,6 +758,12 @@ SGL_PY_EXPORT(device_device)
         &Device::register_shader_hot_reload_callback,
         "callback"_a,
         D_NA(Device, register_shader_hot_reload_callback)
+    );
+    device.def(
+        "register_device_close_callback",
+        &Device::register_device_close_callback,
+        "callback"_a,
+        D_NA(Device, register_device_close_callback)
     );
 
     device.def_static(


### PR DESCRIPTION
- Enabled use of python weakref to refer to device
- Added callback+tests for capturing device close event