### PR TITLE
Coop Vec API Cleanup

### DIFF
--- a/src/sgl/device/coopvec.cpp
+++ b/src/sgl/device/coopvec.cpp
@@ -9,8 +9,8 @@
 
 namespace sgl {
 
-CoopVec::CoopVec(ref<Device> device)
-    : m_device(device.get())
+CoopVec::CoopVec(Device* device)
+    : m_device(device)
 {
     SGL_CHECK(device->type() == DeviceType::vulkan, "Requires a Vulkan device");
     bool have_coop_vec = false;
@@ -271,9 +271,9 @@ size_t CoopVec::convert_matrix_host(const void* src, CoopVecMatrixDesc src_desc,
 }
 
 void CoopVec::convert_matrix_device(
-    const ref<Buffer>& src,
+    const Buffer* src,
     CoopVecMatrixDesc src_desc,
-    const ref<Buffer>& dst,
+    const Buffer* dst,
     CoopVecMatrixDesc dst_desc,
     CommandBuffer* cmd
 )
@@ -282,9 +282,9 @@ void CoopVec::convert_matrix_device(
 }
 
 void CoopVec::convert_matrix_device(
-    const ref<Buffer>& src,
+    const Buffer* src,
     const std::vector<CoopVecMatrixDesc>& src_desc,
-    const ref<Buffer>& dst,
+    const Buffer* dst,
     const std::vector<CoopVecMatrixDesc>& dst_desc,
     CommandBuffer* cmd
 )
@@ -300,9 +300,9 @@ void CoopVec::convert_matrix_device(
 }
 
 void CoopVec::convert_matrix_device(
-    const ref<Buffer>& src,
+    const Buffer* src,
     const CoopVecMatrixDesc* src_desc,
-    const ref<Buffer>& dst,
+    const Buffer* dst,
     const CoopVecMatrixDesc* dst_desc,
     uint32_t matrix_count,
     CommandBuffer* cmd
@@ -347,8 +347,8 @@ void CoopVec::convert_matrix_device(
     // Slang GFX doesn't expose this yet, so we use regular ShaderResource / UnorderedAccess states for now.
 
     // Insert barriers to transition source to ShaderResource, and explicit UAV barrier for destination.
-    actual_cmd->set_resource_state(src.get(), ResourceState::shader_resource);
-    actual_cmd->uav_barrier(dst.get());
+    actual_cmd->set_resource_state(src, ResourceState::shader_resource);
+    actual_cmd->uav_barrier(dst);
 
     gfx::InteropHandle handle = {};
     SLANG_CALL(actual_cmd->gfx_command_buffer()->getNativeHandle(&handle));
@@ -359,7 +359,7 @@ void CoopVec::convert_matrix_device(
 
     // Insert barriers to transition destination to ShaderResource.
     // After this point it should be safe to access.
-    actual_cmd->set_resource_state(dst.get(), ResourceState::shader_resource);
+    actual_cmd->set_resource_state(dst, ResourceState::shader_resource);
 
     if (cmd == nullptr)
         m_device->_end_shared_command_buffer(false);

--- a/src/sgl/device/coopvec.cpp
+++ b/src/sgl/device/coopvec.cpp
@@ -15,9 +15,6 @@
 
 namespace sgl {
 
-const size_t CoopVec::k_matrix_alignment;
-const size_t CoopVec::k_vector_alignment;
-
 CoopVec::CoopVec(ref<Device> device)
     : m_device(device.get())
 {
@@ -210,10 +207,10 @@ CoopVecMatrixDesc CoopVec::create_matrix_desc(
 )
 {
     SGL_CHECK(
-        (offset % k_matrix_alignment) == 0,
+        (offset % MATRIX_ALIGNMENT) == 0,
         "Matrix offset %d does not conform to required matrix alignment of %d",
         offset,
-        k_matrix_alignment
+        MATRIX_ALIGNMENT
     );
     CoopVecMatrixDesc result;
     result.rows = rows;

--- a/src/sgl/device/coopvec.cpp
+++ b/src/sgl/device/coopvec.cpp
@@ -12,11 +12,11 @@ namespace sgl {
 CoopVec::CoopVec(Device* device)
     : m_device(device)
 {
-    SGL_CHECK(device->type() == DeviceType::vulkan, "Requires a Vulkan device");
+    SGL_CHECK(device->type() == DeviceType::vulkan, "CoopVec requires a Vulkan device");
     bool have_coop_vec = false;
     for (const auto& f : device->features())
         have_coop_vec = have_coop_vec || f == "cooperative-vector";
-    SGL_CHECK(have_coop_vec, "Requires a Vulkan device with coop_vector support.");
+    SGL_CHECK(have_coop_vec, "Requires a Vulkan device with CoopVec support.");
 
 #if SGL_WINDOWS
     const char* dll_name = "vulkan-1.dll";

--- a/src/sgl/device/coopvec.cpp
+++ b/src/sgl/device/coopvec.cpp
@@ -12,6 +12,7 @@ namespace sgl {
 CoopVec::CoopVec(Device* device)
     : m_device(device)
 {
+#if SGL_WINDOWS || SGL_LINUX
     SGL_CHECK(device->type() == DeviceType::vulkan, "CoopVec requires a Vulkan device");
     bool have_coop_vec = false;
     for (const auto& f : device->features())
@@ -22,9 +23,6 @@ CoopVec::CoopVec(Device* device)
     const char* dll_name = "vulkan-1.dll";
 #elif SGL_LINUX
     const char* dll_name = "libvulkan.so.1";
-#else
-    SGL_THROW("Platform does not support CoopVec");
-    return;
 #endif
 
     m_vk_module = platform::load_shared_library(dll_name);
@@ -56,6 +54,10 @@ CoopVec::CoopVec(Device* device)
         m_VkCmdConvertCooperativeVectorMatrixNV != nullptr,
         "Failed to get Vulkan function 'vkCmdConvertCooperativeVectorMatrixNV'."
     );
+#else
+    SGL_THROW("Platform does not support CoopVec");
+    return;
+#endif
 }
 
 CoopVec::~CoopVec()

--- a/src/sgl/device/coopvec.h
+++ b/src/sgl/device/coopvec.h
@@ -7,6 +7,7 @@
 #include "sgl/core/object.h"
 #include "sgl/core/enum.h"
 #include "sgl/core/data_type.h"
+#include "sgl/core/platform.h"
 
 #include <vector>
 #include <vulkan/vulkan.h>
@@ -97,11 +98,9 @@ public:
     }
 
 private:
-    PFN_vkVoidFunction get_function(const char* name) const;
-
     Device* m_device;
 
-    void* m_vk_module{nullptr};
+    SharedLibraryHandle m_vk_module{nullptr};
     VkDevice m_vk_device{nullptr};
     PFN_vkConvertCooperativeVectorMatrixNV m_VkConvertCooperativeVectorMatrixNV{nullptr};
     PFN_vkCmdConvertCooperativeVectorMatrixNV m_VkCmdConvertCooperativeVectorMatrixNV{nullptr};

--- a/src/sgl/device/coopvec.h
+++ b/src/sgl/device/coopvec.h
@@ -46,8 +46,8 @@ public:
     CoopVec(ref<Device> device);
     ~CoopVec();
 
-    static const size_t k_matrix_alignment = 64; ///< Minimum byte alignment according to spec.
-    static const size_t k_vector_alignment = 16; ///< Minimum byte alignment according to spec.
+    static constexpr size_t MATRIX_ALIGNMENT = 64; ///< Minimum byte alignment according to spec.
+    static constexpr size_t VECTOR_ALIGHMENT = 16; ///< Minimum byte alignment according to spec.
 
     size_t query_matrix_size(uint32_t rows, uint32_t cols, CoopVecMatrixLayout layout, DataType element_type);
 
@@ -89,11 +89,11 @@ public:
 
     size_t align_matrix_offset(size_t offset)
     {
-        return k_matrix_alignment * ((offset + k_matrix_alignment - 1) / k_matrix_alignment);
+        return MATRIX_ALIGNMENT * ((offset + MATRIX_ALIGNMENT - 1) / MATRIX_ALIGNMENT);
     }
     size_t align_vector_offset(size_t offset)
     {
-        return k_vector_alignment * ((offset + k_vector_alignment - 1) / k_vector_alignment);
+        return VECTOR_ALIGHMENT * ((offset + VECTOR_ALIGHMENT - 1) / VECTOR_ALIGHMENT);
     }
 
 private:

--- a/src/sgl/device/coopvec.h
+++ b/src/sgl/device/coopvec.h
@@ -44,7 +44,7 @@ struct CoopVecMatrixDesc {
 class SGL_API CoopVec : public Object {
     SGL_OBJECT(CoopVec)
 public:
-    CoopVec(ref<Device> device);
+    CoopVec(Device* device);
     ~CoopVec();
 
     static constexpr size_t MATRIX_ALIGNMENT = 64; ///< Minimum byte alignment according to spec.
@@ -65,24 +65,24 @@ public:
     size_t convert_matrix_host(const void* src, CoopVecMatrixDesc src_desc, void* dst, CoopVecMatrixDesc dst_desc);
     // Device-to-device conversion of single matrix
     void convert_matrix_device(
-        const ref<Buffer>& src,
+        const Buffer* src,
         CoopVecMatrixDesc src_desc,
-        const ref<Buffer>& dst,
+        const Buffer* dst,
         CoopVecMatrixDesc dst_desc,
         CommandBuffer* cmd = nullptr
     );
     // Device-to-device conversion of multiple matrices
     void convert_matrix_device(
-        const ref<Buffer>& src,
+        const Buffer* src,
         const std::vector<CoopVecMatrixDesc>& src_desc,
-        const ref<Buffer>& dst,
+        const Buffer* dst,
         const std::vector<CoopVecMatrixDesc>& dst_desc,
         CommandBuffer* cmd = nullptr
     );
     void convert_matrix_device(
-        const ref<Buffer>& src,
+        const Buffer* src,
         const CoopVecMatrixDesc* src_desc,
-        const ref<Buffer>& dst,
+        const Buffer* dst,
         const CoopVecMatrixDesc* dst_desc,
         uint32_t matrix_count,
         CommandBuffer* cmd = nullptr

--- a/src/sgl/device/python/coopvec.cpp
+++ b/src/sgl/device/python/coopvec.cpp
@@ -9,112 +9,13 @@
 
 #include <iostream>
 
-namespace sgl {
-
-template<typename... Args>
-static bool ndarray_is_row_maj(const nb::ndarray<Args...>& array)
-{
-    return array.ndim() == 2 && (array.stride(0) == int64_t(array.shape(1)) && array.stride(1) == 1);
-}
-template<typename... Args>
-static bool ndarray_is_col_maj(const nb::ndarray<Args...>& array)
-{
-    return array.ndim() == 2 && (array.stride(0) == 1 && array.stride(1) == int64_t(array.shape(0)));
-}
-
-template<typename... Args>
-static void check_ndarray(const nb::ndarray<Args...>& array)
-{
-    if (array.ndim() == 1)
-        return; // 1D arrays are always ok
-    SGL_CHECK(array.ndim() == 2, "Expected 2-dimensional array (received ndim = %d)", array.ndim());
-    SGL_CHECK(ndarray_is_row_maj(array) || ndarray_is_col_maj(array), "2D arrays must be row or column major");
-}
-template<typename... Args>
-static CoopVecMatrixLayout
-get_ndarray_layout(const nb::ndarray<Args...>& array, std::optional<CoopVecMatrixLayout> hint)
-{
-    if (hint)
-        return hint.value();
-    if (ndarray_is_row_maj(array))
-        return CoopVecMatrixLayout::row_major;
-    if (ndarray_is_col_maj(array))
-        return CoopVecMatrixLayout::column_major;
-    SGL_THROW("Require a 2D row major/column major array when no explicit matrix layout is given");
-}
-template<typename... Args>
-static DataType get_ndarray_element_type(const nb::ndarray<Args...>& array)
-{
-    DataType result = dtype_to_data_type(array.dtype());
-    SGL_CHECK(result != DataType::void_ && result != DataType::bool_, "Invalid coop_vec element type \"%d\"", result);
-    return result;
-}
-template<typename... Args>
-static CoopVecMatrixDesc
-get_ndarray_matrix_desc(const nb::ndarray<Args...>& array, std::optional<CoopVecMatrixLayout> layout_hint)
-{
-    CoopVecMatrixDesc desc;
-    desc.size = array.nbytes();
-    desc.layout = get_ndarray_layout(array, layout_hint);
-    desc.element_type = get_ndarray_element_type(array);
-    desc.rows = array.ndim() > 0 ? uint32_t(array.shape(0)) : 0;
-    desc.cols = array.ndim() > 1 ? uint32_t(array.shape(1)) : 0;
-    return desc;
-}
-
-static const char* __doc_sgl_CoopVec_query_matrix_size = R"doc()doc";
-static const char* __doc_sgl_CoopVec_create_matrix_desc = R"doc()doc";
-static const char* __doc_sgl_CoopVec_convert_matrix = R"doc()doc";
-static const char* __doc_sgl_CoopVec_convert_matrix_device = R"doc()doc";
-static const char* __doc_sgl_CoopVec_matrix_alignment = R"doc()doc";
-static const char* __doc_sgl_CoopVec_vector_alignment = R"doc()doc";
-static const char* __doc_sgl_CoopVec_align_matrix_offset = R"doc()doc";
-static const char* __doc_sgl_CoopVec_align_vector_offset = R"doc()doc";
-
-inline size_t convert_matrix_host_to_host(
-    CoopVec* self,
-    nb::ndarray<nb::device::cpu> src,
-    nb::ndarray<nb::device::cpu> dst,
-    std::optional<CoopVecMatrixLayout> src_layout,
-    std::optional<CoopVecMatrixLayout> dst_layout
-)
-{
-    CoopVecMatrixDesc src_desc = get_ndarray_matrix_desc(src, src_layout);
-    CoopVecMatrixDesc dst_desc = get_ndarray_matrix_desc(dst, dst_layout);
-
-    if (src.ndim() == 2 && dst.ndim() == 2) {
-        SGL_CHECK(
-            src_desc.rows == dst_desc.rows && src_desc.cols == dst_desc.cols,
-            "Array shapes of src and dst do not match ((%d, %d) != (%d, %d))",
-            src_desc.rows,
-            src_desc.cols,
-            dst_desc.rows,
-            dst_desc.cols
-        );
-    } else if (src.ndim() == 2) {
-        dst_desc.rows = src_desc.rows;
-        dst_desc.cols = src_desc.cols;
-    } else if (dst.ndim() == 2) {
-        src_desc.rows = dst_desc.rows;
-        src_desc.cols = dst_desc.cols;
-    } else {
-        SGL_THROW("At least one of src or dst must be a 2D array");
-    }
-
-    return self->convert_matrix_host(src.data(), src_desc, dst.data(), dst_desc);
-}
-
-} // namespace sgl
-
 SGL_PY_EXPORT(device_coopvec)
 {
     using namespace sgl;
 
-    nb::class_<CoopVec> coop_vec(m, "CoopVec", D_NA(CoopVec));
+    nb::sgl_enum<CoopVecMatrixLayout>(m, "CoopVecMatrixLayout", D_NA(CoopVec, MatrixLayout));
 
-    nb::sgl_enum<CoopVecMatrixLayout>(coop_vec, "MatrixLayout", D_NA(CoopVec, MatrixLayout));
-
-    nb::class_<CoopVecMatrixDesc>(coop_vec, "MatrixDesc", D_NA(CoopVec, MatrixDesc))
+    nb::class_<CoopVecMatrixDesc>(m, "CoopVecMatrixDesc", D_NA(CoopVec, MatrixDesc))
         .def(nb::init<>())
         .def(
             "__init__",
@@ -146,55 +47,4 @@ SGL_PY_EXPORT(device_coopvec)
         .def_rw("layout", &CoopVecMatrixDesc::layout, D_NA(CoopVec, MatrixDesc, layout))
         .def_rw("size", &CoopVecMatrixDesc::size, D_NA(CoopVec, MatrixDesc, size))
         .def_rw("offset", &CoopVecMatrixDesc::offset, D_NA(CoopVec, MatrixDesc, offset));
-
-    coop_vec.def("query_matrix_size", &CoopVec::query_matrix_size, D(CoopVec, query_matrix_size))
-        .def(
-            "create_matrix_desc",
-            &CoopVec::create_matrix_desc,
-            "rows"_a,
-            "cols"_a,
-            "layout"_a,
-            "element_type"_a,
-            "offset"_a = 0,
-            D(CoopVec, create_matrix_desc)
-        )
-        .def(
-            "convert_matrix_host",
-            &convert_matrix_host_to_host,
-            "src"_a,
-            "dst"_a,
-            "src_layout"_a = nb::none(),
-            "dst_layout"_a = nb::none(),
-            D(CoopVec, convert_matrix)
-        )
-        .def(
-            "convert_matrix_device",
-            static_cast<
-                void (CoopVec::*)(const ref<Buffer>&, CoopVecMatrixDesc, const ref<Buffer>&, CoopVecMatrixDesc, CommandBuffer*)>(
-                &CoopVec::convert_matrix_device
-            ),
-            "src"_a,
-            "src_desc"_a,
-            "dst"_a,
-            "dst_desc"_a,
-            "cmd"_a = nullptr,
-            D(CoopVec, convert_matrix_device)
-        )
-        .def(
-            "convert_matrix_device",
-            static_cast<
-                void (CoopVec::*)(const ref<Buffer>&, const std::vector<CoopVecMatrixDesc>&, const ref<Buffer>&, const std::vector<CoopVecMatrixDesc>&, CommandBuffer*)>(
-                &CoopVec::convert_matrix_device
-            ),
-            "src"_a,
-            "src_desc"_a,
-            "dst"_a,
-            "dst_desc"_a,
-            "cmd"_a = nullptr,
-            D(CoopVec, convert_matrix_device)
-        )
-        .def("align_matrix_offset", &CoopVec::align_matrix_offset, "offset"_a, D(CoopVec, align_matrix_offset))
-        .def("align_vector_offset", &CoopVec::align_vector_offset, "offset"_a, D(CoopVec, align_vector_offset))
-        .def_ro_static("matrix_alignment", &CoopVec::k_matrix_alignment, D(CoopVec, matrix_alignment))
-        .def_ro_static("vector_alignment", &CoopVec::k_vector_alignment, D(CoopVec, vector_alignment));
 }

--- a/src/sgl/device/tests/test_coopvec.py
+++ b/src/sgl/device/tests/test_coopvec.py
@@ -38,13 +38,13 @@ def test_matrix_size(
 ):
     device = get_coop_vec_device(device_type)
 
-    sz = device.coop_vec.query_matrix_size(
-        rows, cols, sgl.CoopVec.MatrixLayout.row_major, dtype
+    sz = device.coopvec_query_matrix_size(
+        rows, cols, sgl.CoopVecMatrixLayout.row_major, dtype
     )
     assert sz == expected_size
 
-    sz = device.coop_vec.query_matrix_size(
-        rows, cols, sgl.CoopVec.MatrixLayout.column_major, dtype
+    sz = device.coopvec_query_matrix_size(
+        rows, cols, sgl.CoopVecMatrixLayout.column_major, dtype
     )
     assert sz == expected_size
 
@@ -56,10 +56,10 @@ def test_matrix_size(
 @pytest.mark.parametrize(
     "layout",
     [
-        sgl.CoopVec.MatrixLayout.row_major,
-        sgl.CoopVec.MatrixLayout.column_major,
-        sgl.CoopVec.MatrixLayout.inferencing_optimal,
-        sgl.CoopVec.MatrixLayout.training_optimal,
+        sgl.CoopVecMatrixLayout.row_major,
+        sgl.CoopVecMatrixLayout.column_major,
+        sgl.CoopVecMatrixLayout.inferencing_optimal,
+        sgl.CoopVecMatrixLayout.training_optimal,
     ],
 )
 def test_matrix_desc(
@@ -67,11 +67,11 @@ def test_matrix_desc(
     rows: int,
     cols: int,
     dtype: sgl.DataType,
-    layout: sgl.CoopVec.MatrixLayout,
+    layout: sgl.CoopVecMatrixLayout,
 ):
     device = get_coop_vec_device(device_type)
-    desc = device.coop_vec.create_matrix_desc(rows, cols, layout, dtype)
-    size = device.coop_vec.query_matrix_size(rows, cols, layout, dtype)
+    desc = device.coopvec_create_matrix_desc(rows, cols, layout, dtype)
+    size = device.coopvec_query_matrix_size(rows, cols, layout, dtype)
     assert desc.rows == rows
     assert desc.cols == cols
     assert desc.layout == layout
@@ -86,17 +86,16 @@ def test_matrix_convert_matrix_host(device_type: sgl.DeviceType):
     data = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.float32)
     result = np.zeros_like(data)
 
-    device.coop_vec.convert_matrix_host(
+    device.coopvec_convert_matrix_host(
         data,
         result,
-        sgl.CoopVec.MatrixLayout.row_major,
-        sgl.CoopVec.MatrixLayout.column_major,
+        sgl.CoopVecMatrixLayout.row_major,
+        sgl.CoopVecMatrixLayout.column_major,
     )
 
+    # Conversion should have changed memory layout, but not shape
     data_t = np.transpose(data)
-    result = result.reshape(
-        data_t.shape
-    )  # probably shouldn't have to do this but conversion doesn't change shape
+    result = result.reshape(data_t.shape)
     assert np.allclose(data_t, result)
 
 
@@ -107,17 +106,16 @@ def test_matrix_convert_huge_matrix_host(device_type: sgl.DeviceType):
     data = np.random.random((128, 128)).astype(np.float32)
     result = np.zeros_like(data)
 
-    device.coop_vec.convert_matrix_host(
+    device.coopvec_convert_matrix_host(
         data,
         result,
-        sgl.CoopVec.MatrixLayout.row_major,
-        sgl.CoopVec.MatrixLayout.column_major,
+        sgl.CoopVecMatrixLayout.row_major,
+        sgl.CoopVecMatrixLayout.column_major,
     )
 
+    # Conversion should have changed memory layout, but not shape
     data_t = np.transpose(data)
-    result = result.reshape(
-        data_t.shape
-    )  # probably shouldn't have to do this but conversion doesn't change shape
+    result = result.reshape(data_t.shape)
     assert np.allclose(data_t, result)
 
 
@@ -134,20 +132,20 @@ def test_matrix_convert_matrix_device(device_type: sgl.DeviceType):
         usage=sgl.ResourceUsage.shader_resource | sgl.ResourceUsage.unordered_access,
     )
 
-    data_desc = device.coop_vec.create_matrix_desc(
+    data_desc = device.coopvec_create_matrix_desc(
         data.shape[0],
         data.shape[1],
-        sgl.CoopVec.MatrixLayout.row_major,
+        sgl.CoopVecMatrixLayout.row_major,
         sgl.DataType.float32,
     )
-    result_desc = device.coop_vec.create_matrix_desc(
+    result_desc = device.coopvec_create_matrix_desc(
         data.shape[0],
         data.shape[1],
-        sgl.CoopVec.MatrixLayout.column_major,
+        sgl.CoopVecMatrixLayout.column_major,
         sgl.DataType.float32,
     )
 
-    device.coop_vec.convert_matrix_device(data_buf, data_desc, result_buf, result_desc)
+    device.coopvec_convert_matrix_device(data_buf, data_desc, result_buf, result_desc)
 
     result = result_buf.to_numpy().view(np.float32).reshape(data.shape)
 


### PR DESCRIPTION
Cleanup to the coopvec API:

Move python API from CoopVec to Device
Use platform functions to deal with shared libraries
Switch to using pointers instead of refs<>
Clean up naming of alignment constants in CoopVec