### PR TITLE
More robust search for libcuda 

### DIFF
--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/xwanhm0q8hlg7qfm022gyy4k6i1yn1r6-python3.12-sgl-0.12.2

--- a/src/sgl/device/cuda_api.cpp
+++ b/src/sgl/device/cuda_api.cpp
@@ -23,10 +23,7 @@ bool sgl_cuda_api_init()
 #if SGL_WINDOWS
     std::vector<std::string> cuda_paths{"nvcuda.dll"};
 #elif SGL_LINUX
-    std::vector<std::string> cuda_paths{
-        "/usr/lib/x86_64-linux-gnu/libcuda.so",
-        "/usr/lib/aarch64-linux-gnu/libcuda.so",
-    };
+    std::vector<std::string> cuda_paths{"libcuda.so"};
 #else
     std::vector<std::string> cuda_paths;
     return false;


### PR DESCRIPTION
Just use the system linker as intended

It mitigates https://github.com/shader-slang/slangpy/issues/43 for me,
but doesn't solve the underlying bug