### PR TITLE
Option to disable automatic loading of buffer data on first write

### DIFF
--- a/src/sgl/device/buffer_cursor.h
+++ b/src/sgl/device/buffer_cursor.h
@@ -101,11 +101,19 @@ public:
     /// Create buffer + allocate space internally for a given number of elements.
     BufferCursor(ref<TypeLayoutReflection> element_layout, size_t element_count);
 
-    /// Create as a view onto a buffer resource.
-    BufferCursor(ref<TypeLayoutReflection> element_layout, ref<Buffer> resource);
+    /// Create as a view onto a buffer resource. Disable load_before_write to
+    /// prevent automatic loading of current buffer state before writing data to it.
+    BufferCursor(ref<TypeLayoutReflection> element_layout, ref<Buffer> resource, bool load_before_write = true);
 
-    /// Create as a view onto a section of a buffer resource.
-    BufferCursor(ref<TypeLayoutReflection> element_layout, ref<Buffer> resource, size_t size, size_t offset);
+    /// Create as a view onto a section of a buffer resource. Disable load_before_write to
+    /// prevent automatic loading of current buffer state before writing data to it.
+    BufferCursor(
+        ref<TypeLayoutReflection> element_layout,
+        ref<Buffer> resource,
+        size_t size,
+        size_t offset,
+        bool load_before_write = true
+    );
 
     ~BufferCursor();
 
@@ -158,6 +166,7 @@ private:
     size_t m_size{0};
     bool m_owner{false};
     DeviceOffset m_offset{0};
+    bool m_load_before_write{true};
 };
 
 

--- a/src/sgl/device/python/buffer_cursor.cpp
+++ b/src/sgl/device/python/buffer_cursor.cpp
@@ -87,7 +87,7 @@ SGL_PY_EXPORT(device_buffer_cursor)
             nb::init<ref<TypeLayoutReflection>, ref<Buffer>, bool>(),
             "element_layout"_a,
             "buffer_resource"_a,
-            "load_buffer_write"_a = true,
+            "load_before_write"_a = true,
             D_NA(BufferCursor, BufferCursor)
         )
         .def(
@@ -96,7 +96,7 @@ SGL_PY_EXPORT(device_buffer_cursor)
             "buffer_resource"_a,
             "size"_a,
             "offset"_a,
-            "load_buffer_write"_a = true,
+            "load_before_write"_a = true,
             D_NA(BufferCursor, BufferCursor)
         )
         .def_prop_ro("element_type_layout", &BufferCursor::element_type_layout, D_NA(BufferCursor, type_layout))

--- a/src/sgl/device/python/buffer_cursor.cpp
+++ b/src/sgl/device/python/buffer_cursor.cpp
@@ -84,17 +84,19 @@ SGL_PY_EXPORT(device_buffer_cursor)
             D_NA(BufferCursor, BufferCursor)
         )
         .def(
-            nb::init<ref<TypeLayoutReflection>, ref<Buffer>>(),
+            nb::init<ref<TypeLayoutReflection>, ref<Buffer>, bool>(),
             "element_layout"_a,
             "buffer_resource"_a,
+            "load_buffer_write"_a = true,
             D_NA(BufferCursor, BufferCursor)
         )
         .def(
-            nb::init<ref<TypeLayoutReflection>, ref<Buffer>, size_t, size_t>(),
+            nb::init<ref<TypeLayoutReflection>, ref<Buffer>, size_t, size_t, bool>(),
             "element_layout"_a,
             "buffer_resource"_a,
             "size"_a,
             "offset"_a,
+            "load_buffer_write"_a = true,
             D_NA(BufferCursor, BufferCursor)
         )
         .def_prop_ro("element_type_layout", &BufferCursor::element_type_layout, D_NA(BufferCursor, type_layout))


### PR DESCRIPTION
Currently, to avoid memory stomping, the BufferCursor automatically loads the state of a buffer from the gpu before the user is able to write to it. This is good default behaviour, but if you know the buffer is just garbage, forcing a sync just to load it is wasteful! Added bool to disable that behaviour when you know it's safe to do so.