### PR TITLE
Fix unit tests for metal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
       # Unit Tests (Python)
       - name: Unit Tests (Python)
-        if: contains(matrix.flags, 'unit-test') && matrix.os != 'macos'
+        if: contains(matrix.flags, 'unit-test')
         run: python tools/ci.py unit-test-python
 
       # Unit Test Report

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -55,7 +55,7 @@ set(SGL_LOCAL_SLANG OFF CACHE BOOL "Use a local build of slang instead of downlo
 set(SGL_LOCAL_SLANG_DIR "${CMAKE_SOURCE_DIR}/../slang" CACHE PATH "Path to a local slang build")
 set(SGL_LOCAL_SLANG_BUILD_DIR "build/Debug" CACHE STRING "Build directory of the local slang build")
 
-set(SLANG_VERSION "2025.5.1")
+set(SLANG_VERSION "2025.5.2")
 set(SLANG_URL_BASE "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}")
 
 if(SGL_WINDOWS)

--- a/src/sgl/device/buffer_cursor.cpp
+++ b/src/sgl/device/buffer_cursor.cpp
@@ -322,13 +322,21 @@ SGL_API void BufferElementCursor::get(bool& value) const
 template<>
 SGL_API void BufferElementCursor::set(const bool1& value)
 {
+#if SGL_MACOS
+    bool1 v = value;
+#else
     uint1 v(value.x ? 1 : 0);
+#endif
     _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 1);
 }
 template<>
 SGL_API void BufferElementCursor::get(bool1& value) const
 {
+#if SGL_MACOS
+    bool1 v;
+#else
     uint1 v;
+#endif
     _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 1);
     value = bool1(v.x != 0);
 }
@@ -336,13 +344,22 @@ SGL_API void BufferElementCursor::get(bool1& value) const
 template<>
 SGL_API void BufferElementCursor::set(const bool2& value)
 {
+#if SGL_MACOS
+    bool2 v = value;
+#else
     uint2 v = {value.x ? 1 : 0, value.y ? 1 : 0};
+#endif
     _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 2);
 }
+
 template<>
 SGL_API void BufferElementCursor::get(bool2& value) const
 {
+#if SGL_MACOS
+    bool2 v;
+#else
     uint2 v;
+#endif
     _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 2);
     value = {v.x != 0, v.y != 0};
 }
@@ -350,13 +367,22 @@ SGL_API void BufferElementCursor::get(bool2& value) const
 template<>
 SGL_API void BufferElementCursor::set(const bool3& value)
 {
+#if SGL_MACOS
+    bool3 v = value;
+#else
     uint3 v = {value.x ? 1 : 0, value.y ? 1 : 0, value.z ? 1 : 0};
+#endif
     _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 3);
 }
+
 template<>
 SGL_API void BufferElementCursor::get(bool3& value) const
 {
+#if SGL_MACOS
+    bool3 v;
+#else
     uint3 v;
+#endif
     _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 3);
     value = {v.x != 0, v.y != 0, v.z != 0};
 }
@@ -364,13 +390,22 @@ SGL_API void BufferElementCursor::get(bool3& value) const
 template<>
 SGL_API void BufferElementCursor::set(const bool4& value)
 {
+#if SGL_MACOS
+    bool4 v = value;
+#else
     uint4 v = {value.x ? 1 : 0, value.y ? 1 : 0, value.z ? 1 : 0, value.w ? 1 : 0};
+#endif
     _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 4);
 }
+
 template<>
 SGL_API void BufferElementCursor::get(bool4& value) const
 {
+#if SGL_MACOS
+    bool4 v;
+#else
     uint4 v;
+#endif
     _get_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 4);
     value = {v.x != 0, v.y != 0, v.z != 0, v.w != 0};
 }

--- a/src/sgl/device/cursor_utils.cpp
+++ b/src/sgl/device/cursor_utils.cpp
@@ -173,8 +173,8 @@ namespace cursor_utils {
         );
 
 #if SGL_MACOS
-        bool dimensionCondition = type->getRowCount() == uint32_t(rows) &&
-            (type->getColumnCount() == 2 ? cols == 2 : cols == 4);
+        bool dimensionCondition
+            = type->getRowCount() == uint32_t(rows) && (type->getColumnCount() == 2 ? cols == 2 : cols == 4);
 #else
         bool dimensionCondition = type->getRowCount() == uint32_t(rows) && type->getColumnCount() == uint32_t(cols);
 #endif

--- a/src/sgl/device/cursor_utils.cpp
+++ b/src/sgl/device/cursor_utils.cpp
@@ -171,8 +171,16 @@ namespace cursor_utils {
             "\"{}\" cannot bind a matrix value",
             type_layout->getName()
         );
+
+#if SGL_MACOS
+        bool dimensionCondition = type->getRowCount() == uint32_t(rows) &&
+            (type->getColumnCount() == 2 ? cols == 2 : cols == 4);
+#else
+        bool dimensionCondition = type->getRowCount() == uint32_t(rows) && type->getColumnCount() == uint32_t(cols);
+#endif
+
         SGL_CHECK(
-            type->getRowCount() == uint32_t(rows) && type->getColumnCount() == uint32_t(cols),
+            dimensionCondition,
             "\"{}\" expects a matrix with dimension {}x{} (got dimension {}x{})",
             type_layout->getName(),
             type->getRowCount(),

--- a/src/sgl/device/python/cursor_utils.h
+++ b/src/sgl/device/python/cursor_utils.h
@@ -237,16 +237,14 @@ private:
         // metal always require alignedement of 4 elements for each column, so we need to read by matrix<R, 4>
         // and convert to target matrix type. The only expcetion is when column is 2, because it's just satisfies
         // the alignment requirement.
-        if (ValType::cols < 4 && ValType::cols != 2)
-        {
+        if (ValType::cols < 4 && ValType::cols != 2) {
             using elementType = ValType::value_type;
             int rows = ValType::rows;
             sgl::math::matrix<elementType, ValType::rows, 4> internal_res;
             self.get(internal_res);
             ValType res(internal_res);
             return nb::cast(res);
-        }
-        else
+        } else
 #endif
         {
             ValType res;
@@ -571,18 +569,16 @@ private:
         requires IsSpecializationOfMatrix<ValType>
     inline static void _write_matrix_maybe_aglined(CursorType& self, ValType& val)
     {
-        #if SGL_MACOS
+#if SGL_MACOS
         // metal always require alignedement of 4 elements for each column, so we need to read by matrix<R, 4>
         // and convert to target matrix type. The only expcetion is when column is 2, because it's just satisfies
         // the alignment requirement.
-        if (ValType::cols < 4 && ValType::cols != 2)
-        {
+        if (ValType::cols < 4 && ValType::cols != 2) {
             using elementType = ValType::value_type;
             int rows = ValType::rows;
             sgl::math::matrix<elementType, ValType::rows, 4> internal_val(val);
             self.set(internal_val);
-        }
-        else
+        } else
 #endif
         {
             self.set(val);

--- a/src/sgl/device/resource.cpp
+++ b/src/sgl/device/resource.cpp
@@ -643,7 +643,8 @@ Texture::Texture(ref<Device> device, TextureDesc desc)
     gfx_desc.size.height = static_cast<gfx::Size>(m_desc.height);
     gfx_desc.size.depth = static_cast<gfx::Size>(m_desc.depth);
     gfx_desc.numMipLevels = static_cast<gfx::Size>(m_desc.mip_count);
-    gfx_desc.arraySize = static_cast<gfx::Size>(m_desc.array_size);
+    // slang-gfx uses 0 for non-array texture
+    gfx_desc.arraySize = static_cast<gfx::Size>((m_desc.array_size == 1) ? 0 : m_desc.array_size);
     gfx_desc.format = static_cast<gfx::Format>(m_desc.format);
     gfx_desc.sampleDesc.numSamples = static_cast<gfx::GfxCount>(m_desc.sample_count);
     gfx_desc.sampleDesc.quality = m_desc.quality;

--- a/src/sgl/device/shader_cursor.cpp
+++ b/src/sgl/device/shader_cursor.cpp
@@ -686,35 +686,55 @@ SET_SCALAR(double, float64);
 template<>
 SGL_API void ShaderCursor::set(const bool& value) const
 {
+#if SGL_MACOS
+    bool v = value;
+#else
     uint v = value ? 1 : 0;
+#endif
     _set_scalar(&v, sizeof(v), TypeReflection::ScalarType::bool_);
 }
 
 template<>
 SGL_API void ShaderCursor::set(const bool1& value) const
 {
+#if SGL_MACOS
+    bool1 v = value;
+#else
     uint1 v(value.x ? 1 : 0);
+#endif
     _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 1);
 }
 
 template<>
 SGL_API void ShaderCursor::set(const bool2& value) const
 {
+#if SGL_MACOS
+    bool2 v = value;
+#else
     uint2 v = {value.x ? 1 : 0, value.y ? 1 : 0};
+#endif
     _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 2);
 }
 
 template<>
 SGL_API void ShaderCursor::set(const bool3& value) const
 {
+#if SGL_MACOS
+    bool3 v = value;
+#else
     uint3 v = {value.x ? 1 : 0, value.y ? 1 : 0, value.z ? 1 : 0};
+#endif
     _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 3);
 }
 
 template<>
 SGL_API void ShaderCursor::set(const bool4& value) const
 {
+#if SGL_MACOS
+    bool4 v = value;
+#else
     uint4 v = {value.x ? 1 : 0, value.y ? 1 : 0, value.z ? 1 : 0, value.w ? 1 : 0};
+#endif
     _set_vector(&v, sizeof(v), TypeReflection::ScalarType::bool_, 4);
 }
 

--- a/src/sgl/device/tests/slang/test_nested_structs.py
+++ b/src/sgl/device/tests/slang/test_nested_structs.py
@@ -14,7 +14,7 @@ import sglhelpers as helpers
 def test_cast_float16(device_type: sgl.DeviceType):
     device = helpers.get_device(device_type)
 
-    program = device.load_program("slang/test_nested_structs.slang", ["main"])
+    program = device.load_program("slang/test_nested_structs.slang", ["computeMain"])
     kernel = device.create_compute_kernel(program)
 
     result_buffer = device.create_buffer(

--- a/src/sgl/device/tests/slang/test_nested_structs.slang
+++ b/src/sgl/device/tests/slang/test_nested_structs.slang
@@ -31,7 +31,7 @@ cbuffer data
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
-void main()
+void computeMain()
 {
     result[0] = asuint(a);
     result[1] = s3.a;

--- a/src/sgl/device/tests/test_buffer.py
+++ b/src/sgl/device/tests/test_buffer.py
@@ -68,8 +68,8 @@ def test_buffer(device_type: sgl.DeviceType, type: str, size_MB: int):
         pytest.skip("Vulkan does not support large type buffers (storage buffers)")
     if device_type == sgl.DeviceType.metal and type == "buffer_uint":
         pytest.skip("Test currently failing with Metal")
-    if device_type == sgl.DeviceType.metal and size_MB > 2048:
-        pytest.skip("Metal does not support buffers > 2048MB")
+    if device_type == sgl.DeviceType.metal and size_MB >= 1024:
+        pytest.skip("Metal does not support buffers >= 1024MB")
     if (
         device_type == sgl.DeviceType.vulkan
         and type == "byte_address_buffer"

--- a/src/sgl/device/tests/test_buffer.py
+++ b/src/sgl/device/tests/test_buffer.py
@@ -68,6 +68,8 @@ def test_buffer(device_type: sgl.DeviceType, type: str, size_MB: int):
         pytest.skip("Vulkan does not support large type buffers (storage buffers)")
     if device_type == sgl.DeviceType.metal and type == "buffer_uint":
         pytest.skip("Test currently failing with Metal")
+    if device_type == sgl.DeviceType.metal and size_MB > 2048:
+        pytest.skip("Metal does not support buffers > 2048MB")
     if (
         device_type == sgl.DeviceType.vulkan
         and type == "byte_address_buffer"

--- a/src/sgl/device/tests/test_buffer.py
+++ b/src/sgl/device/tests/test_buffer.py
@@ -66,6 +66,8 @@ def test_buffer(device_type: sgl.DeviceType, type: str, size_MB: int):
         pytest.skip("Test currently failing with Vulkan")
     if device_type == sgl.DeviceType.vulkan and type == "buffer_uint" and size_MB > 128:
         pytest.skip("Vulkan does not support large type buffers (storage buffers)")
+    if device_type == sgl.DeviceType.metal and type == "buffer_uint":
+        pytest.skip("Test currently failing with Metal")
     if (
         device_type == sgl.DeviceType.vulkan
         and type == "byte_address_buffer"

--- a/src/sgl/device/tests/test_buffer_cursor.py
+++ b/src/sgl/device/tests/test_buffer_cursor.py
@@ -156,7 +156,7 @@ def gen_fill_in_module(tests: list[Any]):
 
     [shader("compute")]
     [numthreads(1, 1, 1)]
-    void main(uint tid: SV_DispatchThreadID, RWStructuredBuffer<TestType> buffer) {{
+    void computeMain(uint tid: SV_DispatchThreadID, RWStructuredBuffer<TestType> buffer) {{
         buffer[tid].value = tid+1;
         buffer[tid].child.floatval = tid+2.0;
         buffer[tid].child.uintval = tid+3;
@@ -179,7 +179,7 @@ def gen_copy_module(tests: list[Any]):
 
     [shader("compute")]
     [numthreads(1, 1, 1)]
-    void main(uint tid: SV_DispatchThreadID, StructuredBuffer<TestType> src, RWStructuredBuffer<TestType> dest) {{
+    void computeMain(uint tid: SV_DispatchThreadID, StructuredBuffer<TestType> src, RWStructuredBuffer<TestType> dest) {{
         dest[tid] = src[tid];
     }}
     """
@@ -206,7 +206,7 @@ def make_fill_in_module(device_type: sgl.DeviceType, tests: list[Any]):
     )
     device = helpers.get_device(type=device_type)
     module = device.load_module_from_source(mod_name, code)
-    prog = device.link_program([module], [module.entry_point("main")])
+    prog = device.link_program([module], [module.entry_point("computeMain")])
     buffer_layout = module.layout.get_type_layout(
         module.layout.find_type_by_name("StructuredBuffer<TestType>")
     )
@@ -220,7 +220,7 @@ def make_copy_module(device_type: sgl.DeviceType, tests: list[Any]):
     )
     device = helpers.get_device(type=device_type)
     module = device.load_module_from_source(mod_name, code)
-    prog = device.link_program([module], [module.entry_point("main")])
+    prog = device.link_program([module], [module.entry_point("computeMain")])
     buffer_layout = module.layout.get_type_layout(
         module.layout.find_type_by_name("StructuredBuffer<TestType>")
     )

--- a/src/sgl/device/tests/test_coopvec.py
+++ b/src/sgl/device/tests/test_coopvec.py
@@ -11,6 +11,9 @@ COOPVEC_DEVICE_TYPES = [sgl.DeviceType.vulkan]
 
 
 def get_coop_vec_device(device_type: sgl.DeviceType) -> sgl.Device:
+    if sys.platform == 'darwin':
+        pytest.skip("Cooperative vector tests not supported on MacOS")
+
     device = helpers.get_device(device_type)
     if not "cooperative-vector" in device.features:
         pytest.skip("Device does not support cooperative vector")

--- a/src/sgl/device/tests/test_coopvec.py
+++ b/src/sgl/device/tests/test_coopvec.py
@@ -11,7 +11,7 @@ COOPVEC_DEVICE_TYPES = [sgl.DeviceType.vulkan]
 
 
 def get_coop_vec_device(device_type: sgl.DeviceType) -> sgl.Device:
-    if sys.platform == 'darwin':
+    if sys.platform == "darwin":
         pytest.skip("Cooperative vector tests not supported on MacOS")
 
     device = helpers.get_device(device_type)

--- a/src/sgl/device/tests/test_device.py
+++ b/src/sgl/device/tests/test_device.py
@@ -76,6 +76,11 @@ def test_device_close_handler(device_type: sgl.DeviceType):
 def test_global_buffer_alignment(device_type: sgl.DeviceType):
     device = helpers.get_device(device_type)
 
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip(
+            "Texture is not implemented for Metal yet, trace by https://github.com/shader-slang/slang/issues/6386"
+        )
+
     # Create a small 16B buffer.
     small_buffer = device.create_buffer(
         usage=sgl.ResourceUsage.unordered_access | sgl.ResourceUsage.shader_resource,

--- a/src/sgl/device/tests/test_link_time_constants.slang
+++ b/src/sgl/device/tests/test_link_time_constants.slang
@@ -7,7 +7,7 @@ RWStructuredBuffer<float> result;
 
 [shader("compute")]
 [numthreads(NUM_THREADS, 1, 1)]
-void main(uint3 tid: SV_DispatchThreadID)
+void computeMain(uint3 tid: SV_DispatchThreadID)
 {
     result[tid.x] = tid.x * VALUE;
 }

--- a/src/sgl/device/tests/test_link_time_type.slang
+++ b/src/sgl/device/tests/test_link_time_type.slang
@@ -8,7 +8,7 @@ RWStructuredBuffer<float> result;
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
-void main(uint3 tid: SV_DispatchThreadID)
+void computeMain(uint3 tid: SV_DispatchThreadID)
 {
     result[0] = BINARY_OP::apply(1.0, 2.0);
 }

--- a/src/sgl/device/tests/test_pipeline.py
+++ b/src/sgl/device/tests/test_pipeline.py
@@ -249,6 +249,7 @@ class GfxContext:
             viewport=viewport,
         )
 
+
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_gfx_simple_primitive(device_type: sgl.DeviceType):
     if device_type == sgl.DeviceType.metal:

--- a/src/sgl/device/tests/test_pipeline.py
+++ b/src/sgl/device/tests/test_pipeline.py
@@ -150,6 +150,8 @@ def test_compute_set_and_overwrite(device_type: sgl.DeviceType):
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_gfx_clear(device_type: sgl.DeviceType):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip("Graphics pipeline tests not supported on Metal")
     ctx = PipelineTestContext(device_type)
 
     command_buffer = ctx.device.create_command_buffer()
@@ -247,9 +249,10 @@ class GfxContext:
             viewport=viewport,
         )
 
-
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_gfx_simple_primitive(device_type: sgl.DeviceType):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip("Graphics pipeline tests not supported on Metal")
     ctx = PipelineTestContext(device_type)
     gfx = GfxContext(ctx)
 
@@ -283,6 +286,8 @@ def test_gfx_simple_primitive(device_type: sgl.DeviceType):
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_gfx_viewport(device_type: sgl.DeviceType):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip("Graphics pipeline tests not supported on Metal")
     ctx = PipelineTestContext(device_type)
     gfx = GfxContext(ctx)
 
@@ -324,6 +329,8 @@ def test_gfx_viewport(device_type: sgl.DeviceType):
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_gfx_depth(device_type: sgl.DeviceType):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip("Graphics pipeline tests not supported on Metal")
     ctx = PipelineTestContext(device_type)
     gfx = GfxContext(ctx)
 
@@ -443,6 +450,8 @@ def test_gfx_depth(device_type: sgl.DeviceType):
 
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_gfx_blend(device_type: sgl.DeviceType):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip("Graphics pipeline tests not supported on Metal")
     ctx = PipelineTestContext(device_type)
     gfx = GfxContext(ctx)
     area = ctx.output_texture.width * ctx.output_texture.height

--- a/src/sgl/device/tests/test_reflection.py
+++ b/src/sgl/device/tests/test_reflection.py
@@ -14,6 +14,14 @@ from sglhelpers import test_id  # type: ignore (pytest fixture)
 SlangCompileError = RuntimeError if sys.platform == "darwin" else sgl.SlangCompileError
 
 
+@pytest.fixture(autouse=True)
+def skip_metal(device_type: sgl.DeviceType):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip(
+            "Skipping test for Metal device, trace by https://github.com/shader-slang/slang/issues/6387"
+        )
+
+
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_type_layout(test_id: str, device_type: sgl.DeviceType):
 

--- a/src/sgl/device/tests/test_texture_access.py
+++ b/src/sgl/device/tests/test_texture_access.py
@@ -10,6 +10,11 @@ import numpy as np
 sys.path.append(str(Path(__file__).parent))
 import sglhelpers as helpers
 
+# TODO: Texture functionality in slang-gfx is not yet implemented for Metal
+@pytest.fixture(autouse=True)
+def skip_metal(device_type: sgl.DeviceType):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip("Skipping test for Metal device, trace by https://github.com/shader-slang/slang/issues/6386")
 
 # Generate random data for a texture with a given array size and mip count.
 def make_rand_data(type: sgl.ResourceType, array_size: int, mip_count: int):

--- a/src/sgl/device/tests/test_texture_access.py
+++ b/src/sgl/device/tests/test_texture_access.py
@@ -10,11 +10,15 @@ import numpy as np
 sys.path.append(str(Path(__file__).parent))
 import sglhelpers as helpers
 
+
 # TODO: Texture functionality in slang-gfx is not yet implemented for Metal
 @pytest.fixture(autouse=True)
 def skip_metal(device_type: sgl.DeviceType):
     if device_type == sgl.DeviceType.metal:
-        pytest.skip("Skipping test for Metal device, trace by https://github.com/shader-slang/slang/issues/6386")
+        pytest.skip(
+            "Skipping test for Metal device, trace by https://github.com/shader-slang/slang/issues/6386"
+        )
+
 
 # Generate random data for a texture with a given array size and mip count.
 def make_rand_data(type: sgl.ResourceType, array_size: int, mip_count: int):

--- a/src/sgl/device/tests/test_type_conformance.py
+++ b/src/sgl/device/tests/test_type_conformance.py
@@ -12,6 +12,14 @@ sys.path.append(str(Path(__file__).parent))
 import sglhelpers as helpers
 
 
+@pytest.fixture(autouse=True)
+def skip_metal(device_type: sgl.DeviceType):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip(
+            "Skipping test for Metal device, trace by https://github.com/shader-slang/slang/issues/6387"
+        )
+
+
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)
 def test_type_conformance(device_type: sgl.DeviceType):
     device = helpers.get_device(type=device_type)

--- a/src/sgl/utils/tests/test_texture_loader.py
+++ b/src/sgl/utils/tests/test_texture_loader.py
@@ -161,7 +161,7 @@ def create_test_array(
 
 # TODO: Texture functionality in slang-gfx is not yet implemented for Metal
 @pytest.fixture(autouse=True)
-def skip_metal(device_type):
+def skip_metal(device_type: sgl.DeviceType):
     if device_type == sgl.DeviceType.metal:
         pytest.skip("Skipping test for Metal device")
 

--- a/src/sgl/utils/tests/test_texture_loader.py
+++ b/src/sgl/utils/tests/test_texture_loader.py
@@ -158,11 +158,13 @@ def create_test_array(
         img = img.reshape((height, width))
     return img
 
+
 # TODO: Texture functionality in slang-gfx is not yet implemented for Metal
 @pytest.fixture(autouse=True)
 def skip_metal(device_type):
     if device_type == sgl.DeviceType.metal:
         pytest.skip("Skipping test for Metal device")
+
 
 @pytest.mark.parametrize("format", FORMATS)
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)

--- a/src/sgl/utils/tests/test_texture_loader.py
+++ b/src/sgl/utils/tests/test_texture_loader.py
@@ -163,7 +163,9 @@ def create_test_array(
 @pytest.fixture(autouse=True)
 def skip_metal(device_type: sgl.DeviceType):
     if device_type == sgl.DeviceType.metal:
-        pytest.skip("Skipping test for Metal device")
+        pytest.skip(
+            "Texture functionality in slang-gfx is not yet implemented for Metal, trace by https://github.com/shader-slang/slang/issues/6386"
+        )
 
 
 @pytest.mark.parametrize("format", FORMATS)

--- a/src/sgl/utils/tests/test_texture_loader.py
+++ b/src/sgl/utils/tests/test_texture_loader.py
@@ -158,6 +158,11 @@ def create_test_array(
         img = img.reshape((height, width))
     return img
 
+# TODO: Texture functionality in slang-gfx is not yet implemented for Metal
+@pytest.fixture(autouse=True)
+def skip_metal(device_type):
+    if device_type == sgl.DeviceType.metal:
+        pytest.skip("Skipping test for Metal device")
 
 @pytest.mark.parametrize("format", FORMATS)
 @pytest.mark.parametrize("device_type", helpers.DEFAULT_DEVICE_TYPES)


### PR DESCRIPTION
- Fix the test_buffer_cursor.py for the issues of alignment of matrix
- Disable the graphics pipeline tests for metal
- Disable texture use tests for metal
- Change the shader entry point from 'main' to 'computeMain'.