### PR TITLE
Slangpy support with slang-rhi

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -492,7 +492,7 @@ if(SGL_BUILD_PYTHON)
             INCLUDE_PRIVATE # allow us to have functions/variables that start with _
         )
 
-        # Post-process the main stub file.
+        # Post-process the submodule stub file.
         postprocess_stub(${SGL_OUTPUT_DIRECTORY}/python/sgl/${submodule_path}/__init__.pyi "--submodule")
 
     endforeach()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -424,19 +424,18 @@ if(SGL_BUILD_PYTHON)
         sgl/ui/python/ui.cpp
         sgl/ui/python/widgets.cpp
         sgl/utils/python/renderdoc.cpp
-        # TODO(slang-rhi)
-        # sgl/utils/python/slangpy.h
-        # sgl/utils/python/slangpy.cpp
-        # sgl/utils/python/slangpyvalue.h
-        # sgl/utils/python/slangpyvalue.cpp
-        # sgl/utils/python/slangpybuffer.h
-        # sgl/utils/python/slangpybuffer.cpp
-        # sgl/utils/python/slangpyfunction.h
-        # sgl/utils/python/slangpyfunction.cpp
-        # sgl/utils/python/slangpyresources.h
-        # sgl/utils/python/slangpyresources.cpp
-        # sgl/utils/python/slangpytensor.h
-        # sgl/utils/python/slangpytensor.cpp
+        sgl/utils/python/slangpy.h
+        sgl/utils/python/slangpy.cpp
+        sgl/utils/python/slangpyvalue.h
+        sgl/utils/python/slangpyvalue.cpp
+        sgl/utils/python/slangpybuffer.h
+        sgl/utils/python/slangpybuffer.cpp
+        sgl/utils/python/slangpyfunction.h
+        sgl/utils/python/slangpyfunction.cpp
+        sgl/utils/python/slangpyresources.h
+        sgl/utils/python/slangpyresources.cpp
+        sgl/utils/python/slangpytensor.h
+        sgl/utils/python/slangpytensor.cpp
         sgl/utils/python/tev.cpp
         sgl/utils/python/texture_loader.cpp
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -458,11 +458,11 @@ if(SGL_BUILD_PYTHON)
     )
 
     # Post processes (and overwrites) a stub file.
-    function(postprocess_stub stub_file)
+    function(postprocess_stub stub_file args)
         add_custom_command(
             APPEND
             OUTPUT ${stub_file}
-            COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/postprocess_stub.py --file=${stub_file} --quiet
+            COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../tools/postprocess_stub.py --file=${stub_file} ${args} --quiet
             COMMENT "Post-processing stub ${stub_file}"
         )
     endfunction()
@@ -478,7 +478,7 @@ if(SGL_BUILD_PYTHON)
     )
 
     # Post-process the main stub file.
-    postprocess_stub(${SGL_OUTPUT_DIRECTORY}/python/sgl/__init__.pyi)
+    postprocess_stub(${SGL_OUTPUT_DIRECTORY}/python/sgl/__init__.pyi "")
 
     # Generate submodule stub files.
     foreach(submodule IN ITEMS platform thread math ui tev renderdoc slangpy)
@@ -491,6 +491,10 @@ if(SGL_BUILD_PYTHON)
             DEPENDS sgl_ext
             INCLUDE_PRIVATE # allow us to have functions/variables that start with _
         )
+
+        # Post-process the main stub file.
+        postprocess_stub(${SGL_OUTPUT_DIRECTORY}/python/sgl/${submodule_path}/__init__.pyi "--submodule")
+
     endforeach()
 
     if(SGL_MASTER_PROJECT)

--- a/src/sgl/device/python/resource.cpp
+++ b/src/sgl/device/python/resource.cpp
@@ -353,10 +353,10 @@ SGL_PY_EXPORT(device_resource)
             "__init__",
             [](SubresourceRange* self, nb::dict dict) { new (self) SubresourceRange(dict_to_SubresourceRange(dict)); }
         )
-        .def_ro("mip_level", &SubresourceRange::mip_level, D_NA(SubresourceRange, mip_level))
-        .def_ro("mip_count", &SubresourceRange::mip_count, D_NA(SubresourceRange, mip_count))
-        .def_ro("base_array_layer", &SubresourceRange::base_array_layer, D_NA(SubresourceRange, base_array_layer))
-        .def_ro("layer_count", &SubresourceRange::layer_count, D_NA(SubresourceRange, layer_count))
+        .def_rw("mip_level", &SubresourceRange::mip_level, D_NA(SubresourceRange, mip_level))
+        .def_rw("mip_count", &SubresourceRange::mip_count, D_NA(SubresourceRange, mip_count))
+        .def_rw("base_array_layer", &SubresourceRange::base_array_layer, D_NA(SubresourceRange, base_array_layer))
+        .def_rw("layer_count", &SubresourceRange::layer_count, D_NA(SubresourceRange, layer_count))
         .def("__repr__", &SubresourceRange::to_string, D_NA(SubresourceRange, to_string));
 
 #if 0 // TODO(slang-rhi)
@@ -481,6 +481,26 @@ SGL_PY_EXPORT(device_resource)
             "create_view",
             [](Texture* self, nb::dict dict) { return self->create_view(dict_to_TextureViewDesc(dict)); },
             "dict"_a,
+            D_NA(Texture, create_view)
+        )
+        .def(
+            "create_view",
+            [](Texture* self, uint32_t mip_level, uint32_t mip_count, uint32_t base_array_layer, uint32_t layer_count)
+            {
+                TextureViewDesc desc;
+                desc.format = self->format();                
+                desc.subresource_range = {
+                    .mip_level = mip_level,
+                    .mip_count = mip_count,
+                    .base_array_layer = base_array_layer,
+                    .layer_count = layer_count,
+                };
+                return self->create_view(desc);
+            },
+            "mip_level"_a = 0,
+            "mip_count"_a = SubresourceRange::ALL,
+            "base_array_layer"_a = 0,
+            "layer_count"_a = SubresourceRange::ALL,
             D_NA(Texture, create_view)
         )
         .def("to_bitmap", &Texture::to_bitmap, "layer"_a = 0, "mip_level"_a = 0, D(Texture, to_bitmap))

--- a/src/sgl/device/python/resource.cpp
+++ b/src/sgl/device/python/resource.cpp
@@ -485,10 +485,10 @@ SGL_PY_EXPORT(device_resource)
         )
         .def(
             "create_view",
-            [](Texture* self, uint32_t mip_level, uint32_t mip_count, uint32_t base_array_layer, uint32_t layer_count)
+            [](Texture* self, uint32_t mip_level, uint32_t mip_count, uint32_t base_array_layer, uint32_t layer_count, Format format)
             {
                 TextureViewDesc desc;
-                desc.format = self->format();                
+                desc.format = format == Format::undefined ? self->format() : format;                
                 desc.subresource_range = {
                     .mip_level = mip_level,
                     .mip_count = mip_count,
@@ -501,6 +501,7 @@ SGL_PY_EXPORT(device_resource)
             "mip_count"_a = SubresourceRange::ALL,
             "base_array_layer"_a = 0,
             "layer_count"_a = SubresourceRange::ALL,
+            "format"_a = Format::undefined,
             D_NA(Texture, create_view)
         )
         .def("to_bitmap", &Texture::to_bitmap, "layer"_a = 0, "mip_level"_a = 0, D(Texture, to_bitmap))

--- a/src/sgl/python/sgl_ext.cpp
+++ b/src/sgl/python/sgl_ext.cpp
@@ -135,13 +135,12 @@ NB_MODULE(sgl_ext, m_)
     SGL_PY_IMPORT(utils_renderdoc);
 
     m.def_submodule("slangpy", "SlangPy module");
-    // TODO(slang-rhi)
-    // SGL_PY_IMPORT(utils_slangpy);
-    // SGL_PY_IMPORT(utils_slangpy_buffer);
-    // SGL_PY_IMPORT(utils_slangpy_function);
-    // SGL_PY_IMPORT(utils_slangpy_resources);
-    // SGL_PY_IMPORT(utils_slangpy_tensor);
-    // SGL_PY_IMPORT(utils_slangpy_value);
+    SGL_PY_IMPORT(utils_slangpy);
+    SGL_PY_IMPORT(utils_slangpy_buffer);
+    SGL_PY_IMPORT(utils_slangpy_function);
+    SGL_PY_IMPORT(utils_slangpy_resources);
+    SGL_PY_IMPORT(utils_slangpy_tensor);
+    SGL_PY_IMPORT(utils_slangpy_value);
 
     m.def_submodule("tev", "tev image viewer module");
     SGL_PY_IMPORT(utils_tev);

--- a/src/sgl/utils/python/slangpy.cpp
+++ b/src/sgl/utils/python/slangpy.cpp
@@ -340,17 +340,17 @@ nb::object NativeCallData::call(ref<NativeCallRuntimeOptions> opts, nb::args arg
 
 nb::object NativeCallData::append_to(
     ref<NativeCallRuntimeOptions> opts,
-    CommandBuffer* command_buffer,
+    CommandEncoder* command_encoder,
     nb::args args,
     nb::kwargs kwargs
 )
 {
-    return exec(opts, command_buffer, args, kwargs);
+    return exec(opts, command_encoder, args, kwargs);
 }
 
 nb::object NativeCallData::exec(
     ref<NativeCallRuntimeOptions> opts,
-    CommandBuffer* command_buffer,
+    CommandEncoder* command_encoder,
     nb::args args,
     nb::kwargs kwargs
 )
@@ -367,7 +367,7 @@ nb::object NativeCallData::exec(
     auto context = make_ref<CallContext>(m_device, call_shape, m_call_mode);
 
     // Allocate return value if needed.
-    if (!command_buffer && m_call_mode == CallMode::prim) {
+    if (!command_encoder && m_call_mode == CallMode::prim) {
         ref<NativeBoundVariableRuntime> rv_node = m_runtime->find_kwarg("_result");
         if (rv_node && (!kwargs.contains("_result") || kwargs["_result"].is_none())) {
             nb::object output = rv_node->get_python_type()->create_output(context, rv_node.get());
@@ -421,10 +421,10 @@ nb::object NativeCallData::exec(
             }
         }
     };
-    m_kernel->dispatch(uint3(total_threads, 1, 1), bind_vars, command_buffer);
+    m_kernel->dispatch(uint3(total_threads, 1, 1), bind_vars, command_encoder);
 
     // If command_buffer is not null, return early.
-    if (command_buffer != nullptr) {
+    if (command_encoder != nullptr) {
         return nanobind::none();
     }
 
@@ -474,7 +474,7 @@ NativeCallDataCache::NativeCallDataCache()
             (int)tex->desc().type,
             (int)tex->desc().usage,
             (int)tex->desc().format,
-            (int)tex->array_size()
+            (int)tex->desc().array_length
         );
         builder->add(temp);
 

--- a/src/sgl/utils/python/slangpy.h
+++ b/src/sgl/utils/python/slangpy.h
@@ -603,9 +603,9 @@ public:
     /// Call the compute kernel with the provided arguments and keyword arguments.
     nb::object call(ref<NativeCallRuntimeOptions> opts, nb::args args, nb::kwargs kwargs);
 
-    /// Append the compute kernel to a command buffer with the provided arguments and keyword arguments.
+    /// Append the compute kernel to a command encoder with the provided arguments and keyword arguments.
     nb::object
-    append_to(ref<NativeCallRuntimeOptions> opts, CommandBuffer* command_buffer, nb::args args, nb::kwargs kwargs);
+    append_to(ref<NativeCallRuntimeOptions> opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
 
 private:
     ref<Device> m_device;
@@ -616,7 +616,7 @@ private:
     Shape m_last_call_shape;
 
     nb::object
-    exec(ref<NativeCallRuntimeOptions> opts, CommandBuffer* command_buffer, nb::args args, nb::kwargs kwargs);
+    exec(ref<NativeCallRuntimeOptions> opts, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
 };
 
 typedef std::function<bool(const ref<SignatureBuilder>& builder, nb::handle)> BuildSignatureFunc;

--- a/src/sgl/utils/python/slangpyfunction.cpp
+++ b/src/sgl/utils/python/slangpyfunction.cpp
@@ -64,7 +64,7 @@ nb::object NativeFunctionNode::call(NativeCallDataCache* cache, nb::args args, n
 
 void NativeFunctionNode::append_to(
     NativeCallDataCache* cache,
-    CommandBuffer* command_buffer,
+    CommandEncoder* command_encoder,
     nb::args args,
     nb::kwargs kwargs
 )
@@ -86,11 +86,11 @@ void NativeFunctionNode::append_to(
     NativeCallData* call_data = cache->find_call_data(sig);
 
     if (call_data) {
-        call_data->append_to(options, command_buffer, args, kwargs);
+        call_data->append_to(options, command_encoder, args, kwargs);
     } else {
         ref<NativeCallData> new_call_data = generate_call_data(args, kwargs);
         cache->add_call_data(sig, new_call_data);
-        new_call_data->append_to(options, command_buffer, args, kwargs);
+        new_call_data->append_to(options, command_encoder, args, kwargs);
     }
 }
 

--- a/src/sgl/utils/python/slangpyfunction.h
+++ b/src/sgl/utils/python/slangpyfunction.h
@@ -94,7 +94,7 @@ public:
 
     nb::object call(NativeCallDataCache* cache, nb::args args, nb::kwargs kwargs);
 
-    void append_to(NativeCallDataCache* cache, CommandBuffer* command_buffer, nb::args args, nb::kwargs kwargs);
+    void append_to(NativeCallDataCache* cache, CommandEncoder* command_encoder, nb::args args, nb::kwargs kwargs);
 
     virtual ref<NativeCallData> generate_call_data(nb::args args, nb::kwargs kwargs)
     {

--- a/src/sgl/utils/python/slangpytensor.cpp
+++ b/src/sgl/utils/python/slangpytensor.cpp
@@ -108,14 +108,14 @@ ref<NativeTensor> NativeTensor::broadcast_to(const Shape& new_shape) const
     return make_ref<NativeTensor>(new_desc, m_storage, m_grad_in, m_grad_out);
 }
 
-void NativeTensor::clear(CommandBuffer* cmd)
+void NativeTensor::clear(CommandEncoder* cmd)
 {
     if (cmd) {
-        cmd->clear_resource_view(m_storage->get_uav(), uint4(0, 0, 0, 0));
+        cmd->clear_buffer(m_storage);
     } else {
-        ref<CommandBuffer> temp_cmd = device()->create_command_buffer();
-        temp_cmd->clear_resource_view(m_storage->get_uav(), uint4(0, 0, 0, 0));
-        temp_cmd->submit();
+        ref<CommandEncoder> temp_cmd = device()->create_command_encoder();
+        temp_cmd->clear_buffer(m_storage);
+        device()->submit_command_buffer(temp_cmd->finish());
     }
 }
 

--- a/src/sgl/utils/python/slangpytensor.h
+++ b/src/sgl/utils/python/slangpytensor.h
@@ -66,7 +66,7 @@ public:
     ref<NativeTensor> broadcast_to(const Shape& shape) const;
 
     /// Clear tensor to 0s
-    void clear(CommandBuffer* cmd = nullptr);
+    void clear(CommandEncoder* cmd = nullptr);
 
     /// Create a new version of this tensor with associated grads. It is valid for
     /// both input and output grads to refer to the same tensor. If neither grad_in

--- a/src/sgl/utils/python/slangpytensor.h
+++ b/src/sgl/utils/python/slangpytensor.h
@@ -157,7 +157,7 @@ private:
 /// Bare minimum overridable functions to allow python marshall
 /// extensions to utilize the majority of native functionality.
 struct PyNativeTensorMarshall : public NativeTensorMarshall {
-    NB_TRAMPOLINE(NativeTensorMarshall, 4);
+    NB_TRAMPOLINE(NativeTensorMarshall, 5);
 
     Shape get_shape(nb::object data) const override { NB_OVERRIDE(get_shape, data); }
 
@@ -166,6 +166,13 @@ struct PyNativeTensorMarshall : public NativeTensorMarshall {
     {
         NB_OVERRIDE(create_calldata, context, binding, data);
     }
+
+    void read_calldata(CallContext* context, NativeBoundVariableRuntime* binding, nb::object data, nb::object result)
+        const override
+    {
+        NB_OVERRIDE(read_calldata, context, binding, data, result);
+    }
+
 
     nb::object create_output(CallContext* context, NativeBoundVariableRuntime* binding) const override
     {

--- a/tools/postprocess_stub.py
+++ b/tools/postprocess_stub.py
@@ -752,9 +752,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--quiet", action="store_true", help="Suppress output to console"
     )
+    parser.add_argument(
+        "--submodule", action="store_true", help="Mark as a submodule with reduced post processing."
+    )
     args = vars(parser.parse_args())
     input_filename = args["file"]
     output_filename = args.get("out")
+    submodule = args.get("submodule", False)
     if output_filename is None:
         output_filename = input_filename
     QUIET = args.get("quiet", False)
@@ -773,15 +777,17 @@ if __name__ == "__main__":
 
     tree = load_file(input_filename)
 
-    convertable_types = find_convertable_descriptors(tree)
+    if not submodule:
+        convertable_types = find_convertable_descriptors(tree)
 
-    tree = insert_converted_descriptors(tree, convertable_types)
+        tree = insert_converted_descriptors(tree, convertable_types)
 
     tree = insert_typing_imports(tree)
 
-    tree = replace_types(tree, convertable_types)
+    if not submodule:
+        tree = replace_types(tree, convertable_types)
 
-    tree = extend_vector_types(tree)
+        tree = extend_vector_types(tree)
 
     tree = fix_numpy_types(tree)
 


### PR DESCRIPTION
Predominantly just enabled the slangpy code + fixing compile issues.

Also added:
- Limitted preprocessing of submodule type hints (to fix ArrayLike return values)
- Helper version of create_view that takes subresourcerange properties
- Made subresourcerange rw