### PR TITLE
SlangPy NDBuffer/Tensor cleanup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -438,6 +438,8 @@ if(SGL_BUILD_PYTHON)
         sgl/utils/python/slangpy.cpp
         sgl/utils/python/slangpyvalue.h
         sgl/utils/python/slangpyvalue.cpp
+        sgl/utils/python/slangpystridedbufferview.h
+        sgl/utils/python/slangpystridedbufferview.cpp
         sgl/utils/python/slangpybuffer.h
         sgl/utils/python/slangpybuffer.cpp
         sgl/utils/python/slangpyfunction.h

--- a/src/sgl/python/sgl_ext.cpp
+++ b/src/sgl/python/sgl_ext.cpp
@@ -56,6 +56,7 @@ SGL_PY_DECLARE(ui_widgets);
 
 SGL_PY_DECLARE(utils_renderdoc);
 SGL_PY_DECLARE(utils_slangpy);
+SGL_PY_DECLARE(utils_slangpy_strided_buffer_view);
 SGL_PY_DECLARE(utils_slangpy_buffer);
 SGL_PY_DECLARE(utils_slangpy_function);
 SGL_PY_DECLARE(utils_slangpy_resources);
@@ -139,6 +140,7 @@ NB_MODULE(sgl_ext, m_)
 
     m.def_submodule("slangpy", "SlangPy module");
     SGL_PY_IMPORT(utils_slangpy);
+    SGL_PY_IMPORT(utils_slangpy_strided_buffer_view);
     SGL_PY_IMPORT(utils_slangpy_buffer);
     SGL_PY_IMPORT(utils_slangpy_function);
     SGL_PY_IMPORT(utils_slangpy_resources);

--- a/src/sgl/utils/python/slangpy.cpp
+++ b/src/sgl/utils/python/slangpy.cpp
@@ -1108,6 +1108,7 @@ SGL_PY_EXPORT(utils_slangpy)
             nb::rv_policy::reference_internal,
             D_NA(Shape, as_list)
         )
+        .def("calc_contiguous_strides", &Shape::calc_contiguous_strides, D_NA(Shape, calc_contiguous_strides))
         .def("__repr__", &Shape::to_string, D_NA(Shape, to_string))
         .def("__str__", &Shape::to_string, D_NA(Shape, to_string))
         .def(

--- a/src/sgl/utils/python/slangpybuffer.cpp
+++ b/src/sgl/utils/python/slangpybuffer.cpp
@@ -260,10 +260,10 @@ SGL_PY_EXPORT(utils_slangpy_buffer)
         .def(nb::init<>());
 
     nb::class_<NativeNDBuffer, StridedBufferView>(slangpy, "NativeNDBuffer")
-        .def(nb::init<ref<Device>, NativeNDBufferDesc, ref<Buffer>>())
+        .def(nb::init<ref<Device>, NativeNDBufferDesc, ref<Buffer>>(), "device"_a, "desc"_a, "buffer"_a = nullptr)
         .def("broadcast_to", &NativeNDBuffer::broadcast_to, "shape"_a)
         .def("view", &NativeNDBuffer::view, "shape"_a, "strides"_a = Shape(), "offset"_a = 0)
-        .def("__get_item__", &NativeNDBuffer::index);
+        .def("__getitem__", &NativeNDBuffer::index);
 
 
     nb::class_<NativeNDBufferMarshall, NativeMarshall>(slangpy, "NativeNDBufferMarshall") //

--- a/src/sgl/utils/python/slangpybuffer.h
+++ b/src/sgl/utils/python/slangpybuffer.h
@@ -16,37 +16,27 @@
 
 #include "sgl/utils/python/slangpy.h"
 
+#include "slangpystridedbufferview.h"
+
 namespace sgl::slangpy {
 
-struct NativeNDBufferDesc {
-    ref<NativeSlangType> dtype;
-    ref<TypeLayoutReflection> element_layout;
-    Shape shape;
-    Shape strides;
-    ResourceUsage usage{ResourceUsage::shader_resource | ResourceUsage::unordered_access};
-    MemoryType memory_type{MemoryType::device_local};
+struct NativeNDBufferDesc : public StridedBufferViewDesc {
 };
 
-class NativeNDBuffer : public NativeObject {
+class NativeNDBuffer : public StridedBufferView {
 public:
-    NativeNDBuffer(Device* device, NativeNDBufferDesc desc);
+    NativeNDBuffer(Device* device, NativeNDBufferDesc desc, ref<Buffer> storage = nullptr);
+    virtual ~NativeNDBuffer() {}
 
-    Device* device() const { return storage()->device(); }
-    ref<NativeSlangType> dtype() const { return m_desc.dtype; }
-    const Shape& shape() const { return m_desc.shape; }
-    const Shape& strides() const { return m_desc.strides; }
-    size_t element_count() const { return m_desc.shape.element_count(); }
-    ResourceUsage usage() const { return m_desc.usage; }
-    MemoryType memory_type() const { return m_desc.memory_type; }
-    ref<Buffer> storage() const { return m_storage; }
-    size_t element_stride() const { return m_desc.element_layout->stride(); }
+    virtual NativeNDBufferDesc &desc() override { return m_desc; }
+    virtual const NativeNDBufferDesc &desc() const override { return m_desc; }
 
-    ref<BufferCursor> cursor(std::optional<int> start = std::nullopt, std::optional<int> count = std::nullopt) const;
-    nb::dict uniforms() const;
+    ref<NativeNDBuffer> view(Shape shape, Shape strides = Shape(), int offset = 0) const;
+    ref<NativeNDBuffer> broadcast_to(const Shape& shape) const;
+    ref<NativeNDBuffer> index(nb::args args) const;
 
 private:
     NativeNDBufferDesc m_desc;
-    ref<Buffer> m_storage;
 };
 
 

--- a/src/sgl/utils/python/slangpystridedbufferview.cpp
+++ b/src/sgl/utils/python/slangpystridedbufferview.cpp
@@ -289,6 +289,15 @@ void StridedBufferView::index_inplace(nb::args args)
         strides.push_back(cur_strides[dim + j]);
     }
 
+    if (shape.empty()) {
+        // A fully indexed buffer technically returns a 0D buffer
+        // This is not really compatible with the rest of the machinery,
+        // so turn it into a 1D buffer with 1 element instead
+        shape.push_back(1);
+        strides.push_back(1);
+    }
+
+    // Finally, change our view to the new shape/strides/offset
     view_inplace(Shape(shape), Shape(strides), offset);
 }
 

--- a/src/sgl/utils/python/slangpystridedbufferview.cpp
+++ b/src/sgl/utils/python/slangpystridedbufferview.cpp
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <initializer_list>
+#include "nanobind.h"
+
+#include "sgl/device/device.h"
+#include "sgl/device/command.h"
+#include "sgl/device/buffer_cursor.h"
+
+#include "sgl/utils/python/slangpybuffer.h"
+
+namespace sgl::slangpy {
+
+inline std::optional<nb::dlpack::dtype> scalartype_to_dtype(TypeReflection::ScalarType scalar_type)
+{
+    switch (scalar_type) {
+    case TypeReflection::ScalarType::none_:
+        return {};
+    case TypeReflection::ScalarType::void_:
+        return {};
+    case TypeReflection::ScalarType::bool_:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Bool, 8, 1};
+    case TypeReflection::ScalarType::int32:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, 32, 1};
+    case TypeReflection::ScalarType::uint32:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, 32, 1};
+    case TypeReflection::ScalarType::int64:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, 64, 1};
+    case TypeReflection::ScalarType::uint64:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, 64, 1};
+    case TypeReflection::ScalarType::float16:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Float, 16, 1};
+    case TypeReflection::ScalarType::float32:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Float, 32, 1};
+    case TypeReflection::ScalarType::float64:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Float, 64, 1};
+    case TypeReflection::ScalarType::int8:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, 8, 1};
+    case TypeReflection::ScalarType::uint8:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, 8, 1};
+    case TypeReflection::ScalarType::int16:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, 16, 1};
+    case TypeReflection::ScalarType::uint16:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, 16, 1};
+    case TypeReflection::ScalarType::intptr:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, sizeof(intptr_t) * 8, 1};
+    case TypeReflection::ScalarType::uintptr:
+        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, sizeof(uintptr_t) * 8, 1};
+    default:
+        return {};
+    }
+}
+
+ref<NativeSlangType> innermost_type(ref<NativeSlangType> type)
+{
+    ref<NativeSlangType> result = type;
+    while (true) {
+        ref<NativeSlangType> child = result->element_type();
+        if (!child || child == result) {
+            break;
+        }
+        result = child;
+    }
+    return result;
+}
+
+StridedBufferView::StridedBufferView(Device* device, const StridedBufferViewDesc& desc, ref<Buffer> storage)
+{
+    if (!storage) {
+        BufferDesc buffer_desc;
+        buffer_desc.element_count = desc.offset + desc.shape.element_count();
+        buffer_desc.struct_size = desc.element_layout->stride();
+        buffer_desc.usage = desc.usage;
+        buffer_desc.memory_type = desc.memory_type;
+        storage = device->create_buffer(buffer_desc);
+    }
+    m_storage = std::move(storage);
+
+    set_slangpy_signature(
+        fmt::format("[{},{},{}]", desc.dtype->get_type_reflection()->name(), desc.shape.size(), desc.usage)
+    );
+}
+
+ref<BufferCursor> StridedBufferView::cursor(std::optional<int> start, std::optional<int> count) const
+{
+    size_t el_stride = desc().element_layout->stride();
+    size_t size = (count.value_or(element_count())) * el_stride;
+    size_t offset = (desc().offset + start.value_or(0)) * el_stride;
+    return make_ref<BufferCursor>(desc().element_layout, m_storage, size, offset);
+}
+
+nb::dict StridedBufferView::uniforms() const
+{
+    nb::dict res;
+    res["buffer"] = m_storage;
+    res["offset"] = desc().offset;
+    res["strides"] = desc().strides.as_vector();
+    res["shape"] = desc().shape.as_vector();
+    return res;
+}
+
+void StridedBufferView::view_inplace(Shape shape, Shape strides, int offset)
+{
+    SGL_CHECK(shape.valid(), "New shape must be valid");
+
+    if (!strides.valid())
+        strides = shape.calc_contiguous_strides();
+
+    SGL_CHECK(
+        shape.size() == strides.size(),
+        "Shape dimensions ({}) must match stride dimensions ({})",
+        shape.size(),
+        strides.size()
+    );
+
+    desc().shape = shape;
+    desc().strides = strides;
+    desc().offset += offset;
+}
+
+void StridedBufferView::broadcast_to_inplace(const Shape& new_shape)
+{
+    auto& curr_shape_vec = this->shape().as_vector();
+    auto& new_shape_vec = new_shape.as_vector();
+
+    int D = (int)new_shape_vec.size() - (int)curr_shape_vec.size();
+    if (D < 0) {
+        SGL_THROW("Broadcast shape must be larger than tensor shape");
+    }
+
+    for (size_t i = 0; i < curr_shape_vec.size(); ++i) {
+        // TODO: Should this be curr_shape_vec[i] != 1? Waiting for Benedikt response.
+        if (curr_shape_vec[i] != new_shape_vec[D + i] && curr_shape_vec[D + i] != 1) {
+            SGL_THROW(
+                "Current dimension {}({}) must be equal to new dimension {}({}) or 1",
+                D + i,
+                curr_shape_vec[D + i],
+                i,
+                new_shape_vec[i]
+            );
+        }
+    }
+
+    auto& curr_strides_vec = this->strides().as_vector();
+    std::vector<int> new_strides(new_shape.size(), 0);
+    for (size_t i = 0; i < curr_strides_vec.size(); ++i) {
+        if (curr_shape_vec[i] > 1) {
+            new_strides[D + i] = curr_strides_vec[i];
+        }
+    }
+
+    view_inplace(new_shape, Shape(new_strides));
+}
+
+void StridedBufferView::index_inplace(nb::args args)
+{
+    int real_dims = 0;
+    for (auto v: args) {
+        if (nb::isinstance<int>(v))
+            real_dims++;
+    }
+    SGL_CHECK(real_dims < dims(), "Too many indices for buffer of dimension {}", dims());
+
+    auto cur_shape = shape().as_vector();
+    auto cur_strides = strides().as_vector();
+
+    int dim = 0;
+    int offset = 0;
+    std::vector<int> shape, strides;
+
+    for (size_t i = 0; i < args.size(); ++i) {
+        const nb::handle &arg = args[i];
+
+        if (nb::isinstance<int>(arg)) {
+            int idx = nb::cast<int>(arg);
+            SGL_CHECK(
+                idx < cur_shape[dim] && idx >= -cur_shape[dim],
+                "Index {} is out of bounds for dimension {} with size {}",
+                idx,
+                i,
+                cur_shape[dim]
+            );
+            if (idx < 0)
+                idx += cur_shape[dim];
+            offset += idx * cur_strides[dim];
+            dim++;
+        } else if (nb::isinstance<nb::slice>(arg)) {
+            nb::slice slice = nb::cast<nb::slice>(arg);
+
+            auto adjusted = slice.compute(cur_shape[dim]);
+            size_t start = adjusted.get<0>();
+            size_t stop = adjusted.get<1>();
+            size_t step = adjusted.get<2>();
+            size_t slice_length = adjusted.get<3>();
+
+            SGL_CHECK(
+                step > 0,
+                "Slice step must be greater than zero (found stride {} at dimension {})",
+                step,
+                i
+            );
+
+            offset += int(start) * cur_strides[dim];
+            shape.push_back(int(slice_length));
+            strides.push_back(int(step) * cur_strides[dim]);
+            dim++;
+        } else if (nb::isinstance<nb::ellipsis>(arg)) {
+            int eta = dims() - real_dims;
+            for (int j = 0; j < eta; ++j) {
+                shape.push_back(cur_shape[dim + j]);
+                strides.push_back(cur_strides[dim + j]);
+            }
+            dim += eta;
+        } else if (arg.is_none()) {
+            shape.push_back(1);
+            strides.push_back(0);
+        } else {
+            SGL_THROW("Illegal argument at dimension {}", i);
+        }
+    }
+
+    view_inplace(Shape(shape), Shape(strides), offset);
+}
+
+void StridedBufferView::clear(CommandBuffer* cmd)
+{
+    if (cmd) {
+        cmd->clear_resource_view(m_storage->get_uav(), uint4(0, 0, 0, 0));
+    } else {
+        ref<CommandBuffer> temp_cmd = device()->create_command_buffer();
+        temp_cmd->clear_resource_view(m_storage->get_uav(), uint4(0, 0, 0, 0));
+        temp_cmd->submit();
+    }
+}
+
+nb::ndarray<nb::numpy> StridedBufferView::to_numpy() const
+{
+    // Get dlpack type from scalar type.
+    size_t dtype_size = desc().element_layout->stride();
+    ref<NativeSlangType> innermost = innermost_type(dtype());
+    ref<TypeLayoutReflection> innermost_layout = innermost->buffer_type_layout();
+
+    bool is_scalar = innermost_layout->type()->kind() == TypeReflection::Kind::scalar;
+    size_t innermost_size = is_scalar ? innermost_layout->stride() : 1;
+    TypeReflection::ScalarType scalar_type = is_scalar ? innermost_layout->type()->scalar_type() : TypeReflection::ScalarType::uint8;
+    auto dtype_shape = dtype()->get_shape();
+    auto dtype_strides = dtype_shape.calc_contiguous_strides();
+    auto dlpack_type = scalartype_to_dtype(scalar_type);
+
+    // Create data and nanobind capsule to contain the data.
+    size_t byte_offset = desc().offset * dtype_size;
+    size_t data_size = m_storage->size() - byte_offset;
+    void* data = new uint8_t[data_size];
+    m_storage->get_data(data, data_size, byte_offset);
+    nb::capsule owner(data, [](void* p) noexcept { delete[] reinterpret_cast<uint8_t*>(p); });
+
+    // Build sizes/strides arrays in form numpy wants them.
+    std::vector<size_t> sizes;
+    std::vector<int64_t> strides;
+
+    for (size_t i = 0; i < desc().shape.size(); ++i) {
+        sizes.push_back(desc().shape[i]);
+        strides.push_back(desc().strides[i] * dtype_size / innermost_size);
+    }
+    for (size_t i = 0; i < dtype_shape.size(); ++i) {
+        sizes.push_back(dtype_shape[i]);
+        strides.push_back(dtype_strides[i]);
+    }
+    if (!is_scalar) {
+        sizes.push_back(innermost_layout->stride());
+        strides.push_back(1);
+    }
+
+    // Return numpy array.
+    return nb::ndarray<
+        nb::numpy>(data, sizes.size(), sizes.data(), owner, strides.data(), *dlpack_type, nb::device::cpu::value);
+}
+
+void StridedBufferView::copy_from_numpy(nb::ndarray<nb::numpy> data)
+{
+    // TODO: Offset, strides, etc.
+    SGL_CHECK(is_ndarray_contiguous(data), "numpy array is not contiguous");
+
+    size_t buffer_size = storage()->size();
+    size_t data_size = data.nbytes();
+    SGL_CHECK(data_size <= buffer_size, "numpy array is larger than the buffer ({} > {})", data_size, buffer_size);
+
+    storage()->set_data(data.data(), data_size);
+}
+
+} // namespace sgl::slangpy
+
+SGL_PY_EXPORT(utils_slangpy_strided_buffer_view)
+{
+    using namespace sgl;
+    using namespace sgl::slangpy;
+
+    nb::module_ slangpy = m.attr("slangpy");
+
+    nb::class_<StridedBufferViewDesc>(slangpy, "StridedBufferViewDesc")
+        .def(nb::init<>())
+        .def_rw("dtype", &StridedBufferViewDesc::dtype)
+        .def_rw("element_layout", &StridedBufferViewDesc::element_layout)
+        .def_rw("offset", &StridedBufferViewDesc::offset)
+        .def_rw("shape", &StridedBufferViewDesc::shape)
+        .def_rw("strides", &StridedBufferViewDesc::strides)
+        .def_rw("usage", &StridedBufferViewDesc::usage)
+        .def_rw("memory_type", &StridedBufferViewDesc::memory_type);
+
+    nb::class_<StridedBufferView, NativeObject>(slangpy, "StridedBufferView")
+        .def(nb::init<ref<Device>, StridedBufferViewDesc, ref<Buffer>>())
+        .def_prop_ro("device", &StridedBufferView::device)
+        .def_prop_ro("dtype", &StridedBufferView::dtype)
+        .def_prop_ro("offset", &StridedBufferView::offset)
+        .def_prop_ro("shape", &StridedBufferView::shape)
+        .def_prop_ro("strides", &StridedBufferView::strides)
+        .def_prop_ro("element_count", &StridedBufferView::element_count)
+        .def_prop_ro("usage", &StridedBufferView::usage)
+        .def_prop_ro("memory_type", &StridedBufferView::memory_type)
+        .def_prop_ro("storage", &StridedBufferView::storage)
+        .def("clear", &StridedBufferView::clear, "cmd"_a.none() = nullptr)
+        .def("cursor", &StridedBufferView::cursor, "start"_a.none() = std::nullopt, "count"_a.none() = std::nullopt)
+        .def("uniforms", &StridedBufferView::uniforms)
+        .def("to_numpy", &StridedBufferView::to_numpy, D_NA(StridedBufferView, to_numpy))
+        .def("copy_from_numpy", &StridedBufferView::copy_from_numpy, "data"_a, D_NA(StridedBufferView, copy_from_numpy));
+}

--- a/src/sgl/utils/python/slangpystridedbufferview.cpp
+++ b/src/sgl/utils/python/slangpystridedbufferview.cpp
@@ -122,8 +122,12 @@ void StridedBufferView::view_inplace(Shape shape, Shape strides, int offset)
 {
     SGL_CHECK(shape.valid(), "New shape must be valid");
 
-    if (!strides.valid())
+    if (!strides.valid() || strides.size() == 0)
         strides = shape.calc_contiguous_strides();
+
+    for (size_t i = 0; i < strides.size(); ++i) {
+        SGL_CHECK(strides[i] >= 0, "Strides must be positive");
+    }
 
     SGL_CHECK(
         shape.size() == strides.size(),
@@ -135,6 +139,8 @@ void StridedBufferView::view_inplace(Shape shape, Shape strides, int offset)
     desc().shape = shape;
     desc().strides = strides;
     desc().offset += offset;
+
+    SGL_CHECK(desc().offset >= 0, "Buffer view offset is negative!");
 }
 
 void StridedBufferView::broadcast_to_inplace(const Shape& new_shape)

--- a/src/sgl/utils/python/slangpystridedbufferview.cpp
+++ b/src/sgl/utils/python/slangpystridedbufferview.cpp
@@ -350,14 +350,16 @@ nb::ndarray<nb::numpy> StridedBufferView::to_numpy() const
 
 void StridedBufferView::copy_from_numpy(nb::ndarray<nb::numpy> data)
 {
-    // TODO: Offset, strides, etc.
-    SGL_CHECK(is_ndarray_contiguous(data), "numpy array is not contiguous");
+    SGL_CHECK(is_ndarray_contiguous(data), "Source Numpy array must be contiguous");
+    SGL_CHECK(is_contiguous(), "Destination buffer view must be contiguous");
 
-    size_t buffer_size = storage()->size();
+    size_t dtype_size = desc().element_layout->stride();
+    size_t byte_offset = desc().offset * dtype_size;
     size_t data_size = data.nbytes();
-    SGL_CHECK(data_size <= buffer_size, "numpy array is larger than the buffer ({} > {})", data_size, buffer_size);
+    size_t buffer_size = m_storage->size() - byte_offset;
+    SGL_CHECK(data_size <= buffer_size, "Numpy array is larger than the buffer ({} > {})", data_size, buffer_size);
 
-    storage()->set_data(data.data(), data_size);
+    m_storage->set_data(data.data(), data_size, byte_offset);
 }
 
 } // namespace sgl::slangpy

--- a/src/sgl/utils/python/slangpystridedbufferview.cpp
+++ b/src/sgl/utils/python/slangpystridedbufferview.cpp
@@ -197,10 +197,10 @@ void StridedBufferView::index_inplace(nb::args args)
     // This applies to integers and slices
     int real_dims = 0;
     for (auto v: args) {
-        if (nb::isinstance<int>(v))
+        if (nb::isinstance<int>(v) || nb::isinstance<nb::slice>(v))
             real_dims++;
     }
-    SGL_CHECK(real_dims < dims(), "Too many indices for buffer of dimension {}", dims());
+    SGL_CHECK(real_dims <= dims(), "Too many indices for buffer of dimension {}", dims());
 
     auto cur_shape = shape().as_vector();
     auto cur_strides = strides().as_vector();

--- a/src/sgl/utils/python/slangpystridedbufferview.cpp
+++ b/src/sgl/utils/python/slangpystridedbufferview.cpp
@@ -81,6 +81,25 @@ StridedBufferView::StridedBufferView(Device* device, const StridedBufferViewDesc
     );
 }
 
+bool StridedBufferView::is_contiguous() const
+{
+    const auto &shape_vec = shape().as_vector();
+    const auto &stride_vec = strides().as_vector();
+
+    int prod = 1;
+    for (int i = dims() - 1; i >= 0; --i) {
+        // Ignore strides of singleton dimensions
+        if (shape_vec[i] == 1)
+            continue;
+
+        if (stride_vec[i] != prod)
+            return false;
+        prod *= shape_vec[i];
+    }
+
+    return true;
+}
+
 ref<BufferCursor> StridedBufferView::cursor(std::optional<int> start, std::optional<int> count) const
 {
     size_t el_stride = desc().element_layout->stride();
@@ -369,5 +388,6 @@ SGL_PY_EXPORT(utils_slangpy_strided_buffer_view)
         .def("cursor", &StridedBufferView::cursor, "start"_a.none() = std::nullopt, "count"_a.none() = std::nullopt)
         .def("uniforms", &StridedBufferView::uniforms)
         .def("to_numpy", &StridedBufferView::to_numpy, D_NA(StridedBufferView, to_numpy))
-        .def("copy_from_numpy", &StridedBufferView::copy_from_numpy, "data"_a, D_NA(StridedBufferView, copy_from_numpy));
+        .def("copy_from_numpy", &StridedBufferView::copy_from_numpy, "data"_a, D_NA(StridedBufferView, copy_from_numpy))
+        .def("is_contiguous", &StridedBufferView::is_contiguous, D_NA(&StridedBufferView, is_contiguous));
 }

--- a/src/sgl/utils/python/slangpystridedbufferview.cpp
+++ b/src/sgl/utils/python/slangpystridedbufferview.cpp
@@ -157,14 +157,12 @@ void StridedBufferView::broadcast_to_inplace(const Shape& new_shape)
     }
 
     for (size_t i = 0; i < curr_shape_vec.size(); ++i) {
-        // TODO: Should this be curr_shape_vec[i] != 1? Waiting for Benedikt response.
-        if (curr_shape_vec[i] != new_shape_vec[D + i] && curr_shape_vec[D + i] != 1) {
+        if (curr_shape_vec[i] != new_shape_vec[D + i] && curr_shape_vec[i] != 1) {
             SGL_THROW(
-                "Current dimension {}({}) must be equal to new dimension {}({}) or 1",
-                D + i,
-                curr_shape_vec[D + i],
+                "Current dimension {} at index {} must be equal to new dimension {} or 1",
+                curr_shape_vec[i],
                 i,
-                new_shape_vec[i]
+                new_shape_vec[D + i]
             );
         }
     }

--- a/src/sgl/utils/python/slangpystridedbufferview.cpp
+++ b/src/sgl/utils/python/slangpystridedbufferview.cpp
@@ -219,6 +219,12 @@ void StridedBufferView::index_inplace(nb::args args)
         }
     }
 
+    int remaining = dims() - dim;
+    for (int j = 0; j < remaining; ++j) {
+        shape.push_back(cur_shape[dim + j]);
+        strides.push_back(cur_strides[dim + j]);
+    }
+
     view_inplace(Shape(shape), Shape(strides), offset);
 }
 

--- a/src/sgl/utils/python/slangpystridedbufferview.h
+++ b/src/sgl/utils/python/slangpystridedbufferview.h
@@ -50,6 +50,8 @@ public:
     ref<Buffer> storage() const { return m_storage; }
     size_t element_stride() const { return desc().element_layout->stride(); }
 
+    bool is_contiguous() const;
+
     ref<BufferCursor> cursor(std::optional<int> start = std::nullopt, std::optional<int> count = std::nullopt) const;
     nb::dict uniforms() const;
 

--- a/src/sgl/utils/python/slangpystridedbufferview.h
+++ b/src/sgl/utils/python/slangpystridedbufferview.h
@@ -33,6 +33,8 @@ public:
     StridedBufferView(Device* device, const StridedBufferViewDesc& desc, ref<Buffer> storage);
     virtual ~StridedBufferView() {}
 
+    // Derived classes are free to store a desc with extra information, and can provide us
+    // with the desc for the buffer view by implementing these methods
     virtual StridedBufferViewDesc &desc() { SGL_THROW("desc() is not implemented"); }
     virtual const StridedBufferViewDesc &desc() const { SGL_THROW("desc() is not implemented"); }
 
@@ -60,7 +62,9 @@ public:
     void copy_from_numpy(nb::ndarray<nb::numpy> data);
 
 protected:
-    /// In-place versions of view changing methods, to be called in derived classes.
+    // In-place versions of view changing methods.
+    // Derived classes are supposed the non-inplace versions by creating a copy
+    // with the same buffer/view, call the inplace method on the copy, and return it
     void view_inplace(Shape shape, Shape strides = Shape(), int offset = 0);
     void broadcast_to_inplace(const Shape& shape);
     void index_inplace(nb::args args);

--- a/src/sgl/utils/python/slangpystridedbufferview.h
+++ b/src/sgl/utils/python/slangpystridedbufferview.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+#include <map>
+
+#include "nanobind.h"
+
+#include "sgl/core/macros.h"
+#include "sgl/core/fwd.h"
+#include "sgl/core/object.h"
+
+#include "sgl/device/fwd.h"
+#include "sgl/device/resource.h"
+
+#include "sgl/utils/python/slangpy.h"
+
+namespace sgl::slangpy {
+
+struct StridedBufferViewDesc {
+    ref<NativeSlangType> dtype;
+    ref<TypeLayoutReflection> element_layout;
+    int offset{0};
+    Shape shape;
+    Shape strides;
+    ResourceUsage usage{ResourceUsage::shader_resource | ResourceUsage::unordered_access};
+    MemoryType memory_type{MemoryType::device_local};
+};
+
+class StridedBufferView : public NativeObject {
+public:
+    StridedBufferView(Device* device, const StridedBufferViewDesc& desc, ref<Buffer> storage);
+    virtual ~StridedBufferView() {}
+
+    virtual StridedBufferViewDesc &desc() { SGL_THROW("desc() is not implemented"); }
+    virtual const StridedBufferViewDesc &desc() const { SGL_THROW("desc() is not implemented"); }
+
+    Device* device() const { return storage()->device(); }
+    ref<NativeSlangType> dtype() const { return m_desc.dtype; }
+    int offset() const { return m_desc.offset; }
+    const Shape& shape() const { return m_desc.shape; }
+    const Shape& strides() const { return m_desc.strides; }
+    int dims() const { return (int)m_desc.shape.size(); }
+    size_t element_count() const { return m_desc.shape.element_count(); }
+    ResourceUsage usage() const { return m_desc.usage; }
+    MemoryType memory_type() const { return m_desc.memory_type; }
+    ref<Buffer> storage() const { return m_storage; }
+    size_t element_stride() const { return m_desc.element_layout->stride(); }
+
+    ref<BufferCursor> cursor(std::optional<int> start = std::nullopt, std::optional<int> count = std::nullopt) const;
+    nb::dict uniforms() const;
+
+    /// Clear buffer to 0s
+    void clear(CommandBuffer* cmd = nullptr);
+
+    /// Copy to CPU memory as a numpy array of correct stride/shape
+    nb::ndarray<nb::numpy> to_numpy() const;
+    /// Copy from CPU memory (as a numpy array) into GPU buffer
+    void copy_from_numpy(nb::ndarray<nb::numpy> data);
+
+protected:
+    /// In-place versions of view changing methods, to be called in derived classes.
+    void view_inplace(Shape shape, Shape strides = Shape(), int offset = 0);
+    void broadcast_to_inplace(const Shape& shape);
+    void index_inplace(nb::args args);
+
+private:
+    StridedBufferViewDesc m_desc;
+    ref<Buffer> m_storage;
+};
+
+} // namespace sgl::slangpy

--- a/src/sgl/utils/python/slangpystridedbufferview.h
+++ b/src/sgl/utils/python/slangpystridedbufferview.h
@@ -60,6 +60,8 @@ public:
 
     /// Copy to CPU memory as a numpy array of correct stride/shape
     nb::ndarray<nb::numpy> to_numpy() const;
+    /// Map GPU memory to torch tensor of correct stride/shape
+    nb::ndarray<nb::pytorch> to_torch() const;
     /// Copy from CPU memory (as a numpy array) into GPU buffer
     void copy_from_numpy(nb::ndarray<nb::numpy> data);
 

--- a/src/sgl/utils/python/slangpystridedbufferview.h
+++ b/src/sgl/utils/python/slangpystridedbufferview.h
@@ -37,16 +37,16 @@ public:
     virtual const StridedBufferViewDesc &desc() const { SGL_THROW("desc() is not implemented"); }
 
     Device* device() const { return storage()->device(); }
-    ref<NativeSlangType> dtype() const { return m_desc.dtype; }
-    int offset() const { return m_desc.offset; }
-    const Shape& shape() const { return m_desc.shape; }
-    const Shape& strides() const { return m_desc.strides; }
-    int dims() const { return (int)m_desc.shape.size(); }
-    size_t element_count() const { return m_desc.shape.element_count(); }
-    ResourceUsage usage() const { return m_desc.usage; }
-    MemoryType memory_type() const { return m_desc.memory_type; }
+    ref<NativeSlangType> dtype() const { return desc().dtype; }
+    int offset() const { return desc().offset; }
+    const Shape& shape() const { return desc().shape; }
+    const Shape& strides() const { return desc().strides; }
+    int dims() const { return (int)desc().shape.size(); }
+    size_t element_count() const { return desc().shape.element_count(); }
+    ResourceUsage usage() const { return desc().usage; }
+    MemoryType memory_type() const { return desc().memory_type; }
     ref<Buffer> storage() const { return m_storage; }
-    size_t element_stride() const { return m_desc.element_layout->stride(); }
+    size_t element_stride() const { return desc().element_layout->stride(); }
 
     ref<BufferCursor> cursor(std::optional<int> start = std::nullopt, std::optional<int> count = std::nullopt) const;
     nb::dict uniforms() const;
@@ -66,7 +66,6 @@ protected:
     void index_inplace(nb::args args);
 
 private:
-    StridedBufferViewDesc m_desc;
     ref<Buffer> m_storage;
 };
 

--- a/src/sgl/utils/python/slangpytensor.cpp
+++ b/src/sgl/utils/python/slangpytensor.cpp
@@ -88,7 +88,7 @@ ref<NativeTensor> NativeTensor::with_grads(ref<NativeTensor> grad_in, ref<Native
 
     // Create a new tensor object that refers to the same data as this one, but with
     // associated grads.
-    ref<NativeTensor> result = make_ref<NativeTensor>(m_desc, m_storage, new_grad_in, new_grad_out);
+    ref<NativeTensor> result = make_ref<NativeTensor>(m_desc, storage(), new_grad_in, new_grad_out);
 
     // Optionally clear both.
     if (zero) {

--- a/src/sgl/utils/python/slangpytensor.cpp
+++ b/src/sgl/utils/python/slangpytensor.cpp
@@ -277,7 +277,7 @@ SGL_PY_EXPORT(utils_slangpy_tensor)
         .def_prop_ro("grad", &NativeTensor::grad)
         .def("broadcast_to", &NativeTensor::broadcast_to, "shape"_a)
         .def("view", &NativeTensor::view, "shape"_a, "strides"_a = Shape(), "offset"_a = 0)
-        .def("__get_item__", &NativeTensor::index)
+        .def("__getitem__", &NativeTensor::index)
         .def(
             "with_grads",
             &NativeTensor::with_grads,

--- a/src/sgl/utils/python/slangpytensor.cpp
+++ b/src/sgl/utils/python/slangpytensor.cpp
@@ -5,7 +5,6 @@
 
 #include "sgl/device/device.h"
 #include "sgl/device/buffer_cursor.h"
-#include "sgl/device/command.h"
 
 #include "sgl/utils/python/slangpytensor.h"
 
@@ -17,118 +16,35 @@ extern void write_shader_cursor(ShaderCursor& cursor, nb::object value);
 
 namespace sgl::slangpy {
 
-inline std::optional<nb::dlpack::dtype> scalartype_to_dtype(TypeReflection::ScalarType scalar_type)
-{
-    switch (scalar_type) {
-    case TypeReflection::ScalarType::none_:
-        return {};
-    case TypeReflection::ScalarType::void_:
-        return {};
-    case TypeReflection::ScalarType::bool_:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Bool, 8, 1};
-    case TypeReflection::ScalarType::int32:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, 32, 1};
-    case TypeReflection::ScalarType::uint32:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, 32, 1};
-    case TypeReflection::ScalarType::int64:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, 64, 1};
-    case TypeReflection::ScalarType::uint64:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, 64, 1};
-    case TypeReflection::ScalarType::float16:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Float, 16, 1};
-    case TypeReflection::ScalarType::float32:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Float, 32, 1};
-    case TypeReflection::ScalarType::float64:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Float, 64, 1};
-    case TypeReflection::ScalarType::int8:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, 8, 1};
-    case TypeReflection::ScalarType::uint8:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, 8, 1};
-    case TypeReflection::ScalarType::int16:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, 16, 1};
-    case TypeReflection::ScalarType::uint16:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, 16, 1};
-    case TypeReflection::ScalarType::intptr:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::Int, sizeof(intptr_t) * 8, 1};
-    case TypeReflection::ScalarType::uintptr:
-        return nb::dlpack::dtype{(uint8_t)nb::dlpack::dtype_code::UInt, sizeof(uintptr_t) * 8, 1};
-    default:
-        return {};
-    }
-}
-
 NativeTensor::NativeTensor(
     NativeTensorDesc desc,
     const ref<Buffer>& storage,
     const ref<NativeTensor>& grad_in,
     const ref<NativeTensor>& grad_out
 )
-    : m_desc(desc)
-    , m_storage(storage)
+    : StridedBufferView(storage->device(), desc, storage)
+    , m_desc(desc)
     , m_grad_in(grad_in)
     , m_grad_out(grad_out)
 {
-    set_slangpy_signature(fmt::format("[{},{},{}]", desc.dtype->get_type_reflection()->name(), dims(), usage()));
 }
 
-ref<NativeTensor> NativeTensor::broadcast_to(const Shape& new_shape) const
+ref<NativeTensor> NativeTensor::view(Shape shape, Shape strides, int offset) const
 {
-    auto& curr_shape_vec = this->shape().as_vector();
-    auto& new_shape_vec = new_shape.as_vector();
-
-    int D = (int)new_shape_vec.size() - (int)curr_shape_vec.size();
-    if (D < 0) {
-        SGL_THROW("Broadcast shape must be larger than tensor shape");
-    }
-
-    for (size_t i = 0; i < curr_shape_vec.size(); ++i) {
-        // TODO: Should this be curr_shape_vec[i] != 1? Waiting for Benedikt response.
-        if (new_shape_vec[D + i] != curr_shape_vec[i] && new_shape_vec[D + i] != 1) {
-            SGL_THROW(
-                "New dimension {}({}) must be equal to current dimension {}({}) or 1",
-                D + i,
-                new_shape_vec[D + i],
-                i,
-                curr_shape_vec[i]
-            );
-        }
-    }
-
-    auto& curr_strides_vec = this->strides().as_vector();
-    std::vector<int> new_strides(new_shape.size(), 0);
-    for (size_t i = 0; i < curr_strides_vec.size(); ++i) {
-        if (curr_shape_vec[i] > 1) {
-            new_strides[D + i] = curr_strides_vec[i];
-        }
-    }
-
-    NativeTensorDesc new_desc = m_desc;
-    new_desc.shape = new_shape;
-    new_desc.strides = Shape(new_strides);
-    return make_ref<NativeTensor>(new_desc, m_storage, m_grad_in, m_grad_out);
+    auto result = make_ref<NativeTensor>(desc(), storage(), m_grad_in, m_grad_out);
+    result->view_inplace(shape, strides, offset);
+    return result;
 }
-
-void NativeTensor::clear(CommandBuffer* cmd)
+ref<NativeTensor> NativeTensor::broadcast_to(const Shape& shape) const
 {
-    if (cmd) {
-        cmd->clear_resource_view(m_storage->get_uav(), uint4(0, 0, 0, 0));
-    } else {
-        ref<CommandBuffer> temp_cmd = device()->create_command_buffer();
-        temp_cmd->clear_resource_view(m_storage->get_uav(), uint4(0, 0, 0, 0));
-        temp_cmd->submit();
-    }
+    auto result = make_ref<NativeTensor>(desc(), storage(), m_grad_in, m_grad_out);
+    result->broadcast_to_inplace(shape);
+    return result;
 }
-
-ref<NativeSlangType> innermost_type(ref<NativeSlangType> type)
+ref<NativeTensor> NativeTensor::index(nb::args args) const
 {
-    ref<NativeSlangType> result = type;
-    while (true) {
-        ref<NativeSlangType> child = result->element_type();
-        if (!child || child == result) {
-            break;
-        }
-        result = child;
-    }
+    auto result = make_ref<NativeTensor>(desc(), storage(), m_grad_in, m_grad_out);
+    result->index_inplace(args);
     return result;
 }
 
@@ -153,14 +69,16 @@ ref<NativeTensor> NativeTensor::with_grads(ref<NativeTensor> grad_in, ref<Native
         buffer_desc.element_count = element_count();
         ref<Buffer> buffer = device()->create_buffer(buffer_desc);
 
+        NativeTensorDesc desc;
+        desc.dtype = dtype;
+        desc.element_layout = layout;
+        desc.shape = m_desc.shape;
+        desc.strides = m_desc.shape.calc_contiguous_strides();
+        desc.offset = m_desc.offset;
+
         // Create new native tensor to hold the grads.
         new_grad_in = make_ref<NativeTensor>(
-            NativeTensorDesc{
-                .dtype = dtype,
-                .element_layout = layout,
-                .shape = m_desc.shape,
-                .strides = m_desc.shape.calc_contiguous_strides(),
-                .offset = m_desc.offset},
+            desc,
             buffer,
             nullptr,
             nullptr
@@ -183,59 +101,6 @@ ref<NativeTensor> NativeTensor::with_grads(ref<NativeTensor> grad_in, ref<Native
     }
 
     return result;
-}
-
-nb::ndarray<nb::numpy> NativeTensor::to_numpy() const
-{
-    // Get dlpack type from scalar type.
-    size_t dtype_size = dtype()->buffer_type_layout()->stride();
-    ref<NativeSlangType> innermost = innermost_type(dtype());
-    ref<TypeLayoutReflection> innermost_layout = innermost->buffer_type_layout();
-    size_t innermost_size = innermost_layout->stride();
-    TypeReflection::ScalarType scalar_type = innermost_layout->type()->scalar_type();
-    auto dlpack_type = scalartype_to_dtype(scalar_type);
-    auto dtype_shape = dtype()->get_shape();
-    auto dtype_strides = dtype_shape.calc_contiguous_strides();
-
-    // Create data and nanobind capsule to contain the data.
-    size_t data_size = m_storage->size();
-    void* data = new uint8_t[data_size];
-    m_storage->get_data(data, data_size);
-    nb::capsule owner(data, [](void* p) noexcept { delete[] reinterpret_cast<uint8_t*>(p); });
-
-    // Build sizes/strides arrays in form numpy wants them.
-    std::vector<size_t> sizes;
-    std::vector<int64_t> strides;
-
-    for (size_t i = 0; i < m_desc.shape.size(); ++i) {
-        sizes.push_back(m_desc.shape[i]);
-        strides.push_back(m_desc.strides[i] * dtype_size / innermost_size);
-    }
-    for (size_t i = 0; i < dtype_shape.size(); ++i) {
-        sizes.push_back(dtype_shape[i]);
-        strides.push_back(dtype_strides[i]);
-    }
-
-    // Return numpy array.
-    return nb::ndarray<
-        nb::numpy>(data, sizes.size(), sizes.data(), owner, strides.data(), *dlpack_type, nb::device::cpu::value);
-}
-
-ref<BufferCursor> NativeTensor::cursor(std::optional<int> start, std::optional<int> count) const
-{
-    size_t el_stride = m_desc.element_layout->stride();
-    size_t size = (count.value_or(element_count())) * el_stride;
-    size_t offset = (start.value_or(0)) * el_stride;
-    return make_ref<BufferCursor>(m_desc.element_layout, m_storage, size, offset);
-}
-
-nb::dict NativeTensor::uniforms() const
-{
-    nb::dict res;
-    res["buffer"] = m_storage;
-    res["strides"] = m_desc.strides.as_vector();
-    res["shape"] = m_desc.shape.as_vector();
-    return res;
 }
 
 Shape NativeTensorMarshall::get_shape(nb::object data) const
@@ -351,14 +216,16 @@ nb::object NativeTensorMarshall::create_output(CallContext* context, NativeBound
     buffer_desc.element_count = shape.element_count();
     ref<Buffer> buffer = context->device()->create_buffer(buffer_desc);
 
+    NativeTensorDesc desc;
+    desc.dtype = dtype;
+    desc.element_layout = layout;
+    desc.shape = shape;
+    desc.strides = shape.calc_contiguous_strides();
+    desc.offset = 0;
+
     // Create new native tensor to hold the grads.
     return nb::cast(make_ref<NativeTensor>(
-        NativeTensorDesc{
-            .dtype = dtype,
-            .element_layout = layout,
-            .shape = shape,
-            .strides = shape.calc_contiguous_strides(),
-            .offset = 0},
+        desc,
         buffer,
         nullptr,
         nullptr
@@ -379,6 +246,7 @@ nb::object NativeTensorMarshall::create_dispatchdata(nb::object data) const
     auto buffer = nb::cast<NativeTensor*>(data);
     nb::dict res;
     res["buffer"] = buffer->storage();
+    res["offset"] = buffer->offset();
     res["_shape"] = buffer->shape().as_vector();
     res["strides"] = buffer->strides().as_vector();
     return res;
@@ -393,15 +261,10 @@ SGL_PY_EXPORT(utils_slangpy_tensor)
 
     nb::module_ slangpy = m.attr("slangpy");
 
-    nb::class_<NativeTensorDesc>(slangpy, "NativeTensorDesc")
-        .def(nb::init<>())
-        .def_rw("dtype", &NativeTensorDesc::dtype)
-        .def_rw("element_layout", &NativeTensorDesc::element_layout)
-        .def_rw("shape", &NativeTensorDesc::shape)
-        .def_rw("strides", &NativeTensorDesc::strides)
-        .def_rw("offset", &NativeTensorDesc::offset);
+    nb::class_<NativeTensorDesc, StridedBufferViewDesc>(slangpy, "NativeTensorDesc")
+        .def(nb::init<>());
 
-    nb::class_<NativeTensor, NativeObject>(slangpy, "NativeTensor")
+    nb::class_<NativeTensor, StridedBufferView>(slangpy, "NativeTensor")
         .def(
             nb::init<NativeTensorDesc, const ref<Buffer>&, const ref<NativeTensor>&, const ref<NativeTensor>&>(),
             "desc"_a,
@@ -409,30 +272,19 @@ SGL_PY_EXPORT(utils_slangpy_tensor)
             "grad_in"_a.none(),
             "grad_out"_a.none()
         )
-        .def_prop_ro("device", &NativeTensor::device)
-        .def_prop_ro("dtype", &NativeTensor::dtype)
-        .def_prop_ro("shape", &NativeTensor::shape)
-        .def_prop_ro("strides", &NativeTensor::strides)
-        .def_prop_ro("offset", &NativeTensor::offset)
-        .def_prop_ro("element_count", &NativeTensor::element_count)
-        .def_prop_ro("usage", &NativeTensor::usage)
-        .def_prop_ro("memory_type", &NativeTensor::memory_type)
-        .def_prop_ro("storage", &NativeTensor::storage)
         .def_prop_rw("grad_in", &NativeTensor::grad_in, &NativeTensor::set_grad_in, nb::none())
         .def_prop_rw("grad_out", &NativeTensor::grad_out, &NativeTensor::set_grad_out, nb::none())
         .def_prop_ro("grad", &NativeTensor::grad)
         .def("broadcast_to", &NativeTensor::broadcast_to, "shape"_a)
-        .def("clear", &NativeTensor::clear, "cmd"_a.none() = nullptr)
+        .def("view", &NativeTensor::view, "shape"_a, "strides"_a = Shape(), "offset"_a = 0)
+        .def("__get_item__", &NativeTensor::index)
         .def(
             "with_grads",
             &NativeTensor::with_grads,
             "grad_in"_a.none() = nullptr,
             "grad_out"_a.none() = nullptr,
             "zero"_a = false
-        )
-        .def("cursor", &NativeTensor::cursor, "start"_a.none() = std::nullopt, "count"_a.none() = std::nullopt)
-        .def("uniforms", &NativeTensor::uniforms)
-        .def("to_numpy", &NativeTensor::to_numpy, D_NA(NativeTensor, to_numpy));
+        );
 
 
     nb::class_<NativeTensorMarshall, PyNativeTensorMarshall, NativeMarshall>(slangpy, "NativeTensorMarshall") //

--- a/src/sgl/utils/python/slangpytensor.h
+++ b/src/sgl/utils/python/slangpytensor.h
@@ -63,7 +63,6 @@ public:
 
 private:
     NativeTensorDesc m_desc;
-    ref<Buffer> m_storage;
     ref<NativeTensor> m_grad_in;
     ref<NativeTensor> m_grad_out;
 };

--- a/src/sgl/utils/python/slangpytensor.h
+++ b/src/sgl/utils/python/slangpytensor.h
@@ -16,19 +16,16 @@
 
 #include "sgl/utils/python/slangpy.h"
 
+#include "slangpystridedbufferview.h"
+
 namespace sgl::slangpy {
 
 class NativeTensor;
 
-struct NativeTensorDesc {
-    ref<NativeSlangType> dtype;
-    ref<TypeLayoutReflection> element_layout;
-    Shape shape;
-    Shape strides;
-    int offset{0};
+struct NativeTensorDesc : public StridedBufferViewDesc {
 };
 
-class NativeTensor : public NativeObject {
+class NativeTensor : public StridedBufferView {
 public:
     NativeTensor(
         NativeTensorDesc desc,
@@ -36,18 +33,14 @@ public:
         const ref<NativeTensor>& grad_in,
         const ref<NativeTensor>& grad_out
     );
+    virtual ~NativeTensor() {}
 
-    Device* device() const { return storage()->device(); }
-    ref<NativeSlangType> dtype() const { return m_desc.dtype; }
-    const Shape& shape() const { return m_desc.shape; }
-    const Shape& strides() const { return m_desc.strides; }
-    int dims() const { return (int)m_desc.shape.size(); }
-    int offset() const { return m_desc.offset; }
-    size_t element_count() const { return m_desc.shape.element_count(); }
-    ResourceUsage usage() const { return m_storage->desc().usage; }
-    MemoryType memory_type() const { return m_storage->desc().memory_type; }
-    ref<Buffer> storage() const { return m_storage; }
-    size_t element_stride() const { return m_desc.element_layout->stride(); }
+    virtual NativeTensorDesc &desc() override { return m_desc; }
+    virtual const NativeTensorDesc &desc() const override { return m_desc; }
+
+    ref<NativeTensor> view(Shape shape, Shape strides = Shape(), int offset = 0) const;
+    ref<NativeTensor> broadcast_to(const Shape& shape) const;
+    ref<NativeTensor> index(nb::args args) const;
 
     const ref<NativeTensor>& grad_in() const { return m_grad_in; }
     void set_grad_in(const ref<NativeTensor>& grad_in) { m_grad_in = grad_in; }
@@ -62,23 +55,11 @@ public:
         return m_grad_out;
     }
 
-    /// Broadcast tensor to new shape using standard numpy broadcasting rules.
-    ref<NativeTensor> broadcast_to(const Shape& shape) const;
-
-    /// Clear tensor to 0s
-    void clear(CommandBuffer* cmd = nullptr);
-
     /// Create a new version of this tensor with associated grads. It is valid for
     /// both input and output grads to refer to the same tensor. If neither grad_in
     /// or grad_out are provided, a single new tensor is created and used for both grads.
     ref<NativeTensor>
     with_grads(ref<NativeTensor> grad_in = nullptr, ref<NativeTensor> grad_out = nullptr, bool zero = false) const;
-
-    /// Copy to CPU memory as a numpy array of correct stride/shape
-    nb::ndarray<nb::numpy> to_numpy() const;
-
-    ref<BufferCursor> cursor(std::optional<int> start = std::nullopt, std::optional<int> count = std::nullopt) const;
-    nb::dict uniforms() const;
 
 private:
     NativeTensorDesc m_desc;


### PR DESCRIPTION
This PR creates a shared base class to unify the logic and behavior of Slangpy's `NDBuffer` and `Tensor`.

Currently, `NDBuffer` and `Tensor` offer similar functionality, but often subtly different, or supported in one but not the other. This PR takes a step towards cleaning this up and aligning the two. This also fixes some latent bugs in the code and adds missing functionality of indexing and views.

Overview of changes:
- New `StridedBufferView` base class that represents an SGL buffer with strides/view/offset applied.
- `to_numpy` now behaves identically between `NDBuffer` and Tensor. Before, `NDBuffer.to_numpy` would return a flat buffer of bytes. `Tensor.to_numpy` would try to return a buffer of scalars and return `None` on failure
    - The new `to_numpy` always returns a valid ndarray, with behavior depending on the slang dtype.
    - If the dtype is an array/vector (possible nested), its shape is appended to the shape of the `NDBuffer`/`Tensor`
    - If the innermost dtype is a scalar compatible with numpy, it is mapped to the equivalent numpy dtype
    - If the innermost dtype is not a scalar, it is converted to a 1D array of bytes and appended to the result shape
    - Examples:
        `NDBuffer` of dtype `float3` with shape `(4, 5)` -> ndarray of dtype `np.float32` with shape `(4, 5, 3)`
        `NDBuffer` of dtype `struct Foo {...}` with shape `(5, )` -> ndarray of dtype `np.uint8` with shape `(5, sizeof(Foo))`
    - `to_numpy` respects offsets and strides

- `to_torch` is now supported by both `NDBuffer` and `Tensor`, and its behavior now matches that of `to_numpy` (just in a different framework)

- `NDBuffer`/`Tensor` now support indexing. E.g. for an `NDBuffer` of shape `(64, 32)`, indexing `buffer[4]` will return an `NDBuffer` of shape `(32, )`, representing a 1D view of a slice of the original `NDBuffer`. Partial indexing, slicing and ellipses are supported.

- `Tensor`/`NDBuffer` now have a .view() method for creating new views of the same storage. This can be used to implement currently unimplemented operations

- `broadcast_to` is now supported by NDBuffer as well

- `Tensor.numpy` is deprecated in favor of `Tensor.from_numpy`