### PR TITLE
Rework command buffer submission

### DIFF
--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -657,12 +657,12 @@ uint64_t Device::submit_command_buffer(CommandBuffer* command_buffer, CommandQue
     return submit_command_buffers(command_buffers, {}, {}, {}, {}, queue);
 }
 
-bool Device::is_command_buffer_complete(uint64_t id)
+bool Device::is_submit_finished(uint64_t id)
 {
     return id <= m_global_fence->current_value();
 }
 
-void Device::wait_command_buffer(uint64_t id)
+void Device::wait_for_submit(uint64_t id)
 {
     m_global_fence->wait(id);
 }

--- a/src/sgl/device/device.cpp
+++ b/src/sgl/device/device.cpp
@@ -535,10 +535,24 @@ ref<CommandEncoder> Device::create_command_encoder(CommandQueueType queue)
     return make_ref<CommandEncoder>(ref(this), rhi_command_encoder);
 }
 
-uint64_t Device::submit_command_buffer(CommandBuffer* command_buffer, CommandQueueType queue)
+uint64_t Device::submit_command_buffers(
+    std::span<CommandBuffer*> command_buffers,
+    std::span<Fence*> wait_fences,
+    std::span<uint64_t> wait_fence_values,
+    std::span<Fence*> signal_fences,
+    std::span<uint64_t> signal_fence_values,
+    CommandQueueType queue
+)
 {
-    SGL_CHECK_NOT_NULL(command_buffer);
     SGL_CHECK(queue == CommandQueueType::graphics, "Only graphics queue is supported.");
+
+    bool has_wait_fence_values = wait_fence_values.size() > 0;
+    bool has_signal_fence_values = signal_fence_values.size() > 0;
+
+    if (has_wait_fence_values && wait_fence_values.size() != wait_fences.size())
+        SGL_THROW("\"wait_fence_values\" size does not match \"wait_fences\" size.");
+    if (has_signal_fence_values && signal_fence_values.size() != signal_fences.size())
+        SGL_THROW("\"signal_fence_values\" size does not match \"signal_fences\" size.");
 
     // Update hot reload system if created.
     // TODO(slang-rhi) need to make sure this is not too expensive.
@@ -548,40 +562,99 @@ uint64_t Device::submit_command_buffer(CommandBuffer* command_buffer, CommandQue
     // TODO make parameter
     void* cuda_stream = 0;
 
-    if (m_supports_cuda_interop && command_buffer->m_cuda_interop_buffers.size() > 0) {
-        for (const auto& buffer : command_buffer->m_cuda_interop_buffers)
-            buffer->copy_from_cuda(cuda_stream);
+    short_vector<rhi::ICommandBuffer*, 8> rhi_command_buffers;
+    short_vector<rhi::IFence*, 8> rhi_wait_fences;
+    short_vector<uint64_t, 8> rhi_wait_fence_values;
+    short_vector<rhi::IFence*, 8> rhi_signal_fences;
+    short_vector<uint64_t, 8> rhi_signal_fence_values;
 
-        sync_to_cuda(cuda_stream);
+    bool needs_cuda_sync = false;
+
+    for (CommandBuffer* command_buffer : command_buffers) {
+        SGL_CHECK_NOT_NULL(command_buffer);
+        rhi_command_buffers.push_back(command_buffer->rhi_command_buffer());
     }
 
-    rhi::ICommandBuffer* rhi_command_buffers[] = {command_buffer->rhi_command_buffer()};
-    rhi::IFence* rhi_wait_fences[] = {m_global_fence->rhi_fence()};
-    uint64_t rhi_wait_fence_values[] = {m_global_fence->signaled_value()};
-    rhi::IFence* rhi_signal_fences[] = {m_global_fence->rhi_fence()};
-    uint64_t rhi_signal_fence_values[] = {m_global_fence->update_signaled_value()};
+    // Handle CUDA interop.
+    if (m_supports_cuda_interop) {
+        for (CommandBuffer* command_buffer : command_buffers) {
+            for (const auto& buffer : command_buffer->m_cuda_interop_buffers) {
+                buffer->copy_from_cuda(cuda_stream);
+                needs_cuda_sync = true;
+            }
+        }
+
+        if (needs_cuda_sync)
+            sync_to_cuda(cuda_stream);
+    }
+
+    // Wait for passed in fences.
+    for (size_t i = 0; i < wait_fences.size(); ++i) {
+        Fence* fence = wait_fences[i];
+        SGL_CHECK_NOT_NULL(fence);
+        rhi_wait_fences.push_back(fence->rhi_fence());
+        uint64_t fence_value = has_wait_fence_values ? wait_fence_values[i] : Fence::AUTO;
+        if (fence_value == Fence::AUTO)
+            fence_value = fence->signaled_value();
+        rhi_wait_fence_values.push_back(fence_value);
+    }
+
+    // Wait for global fence if needed.
+    if (m_wait_global_fence) {
+        rhi_wait_fences.push_back(m_global_fence->rhi_fence());
+        rhi_wait_fence_values.push_back(m_global_fence->signaled_value());
+    }
+
+    // Signal passed in fences.
+    for (size_t i = 0; i < signal_fences.size(); ++i) {
+        Fence* fence = signal_fences[i];
+        SGL_CHECK_NOT_NULL(fence);
+        rhi_signal_fences.push_back(fence->rhi_fence());
+        uint64_t fence_value = has_signal_fence_values ? signal_fence_values[i] : Fence::AUTO;
+        if (fence_value == Fence::AUTO)
+            fence_value = fence->update_signaled_value();
+        rhi_signal_fence_values.push_back(fence_value);
+    }
+
+    // Always signal global fence.
+    rhi_signal_fences.push_back(m_global_fence->rhi_fence());
+    rhi_signal_fence_values.push_back(m_global_fence->update_signaled_value());
+
+    SGL_ASSERT(rhi_wait_fences.size() == rhi_wait_fence_values.size());
+    SGL_ASSERT(rhi_signal_fences.size() == rhi_signal_fence_values.size());
+
     rhi::SubmitDesc rhi_submit_desc{
-        .commandBuffers = rhi_command_buffers,
-        .commandBufferCount = 1,
-        .waitFences = m_wait_global_fence ? rhi_wait_fences : nullptr,
-        .waitFenceValues = m_wait_global_fence ? rhi_wait_fence_values : nullptr,
-        .waitFenceCount = m_wait_global_fence ? 1u : 0u,
-        .signalFences = rhi_signal_fences,
-        .signalFenceValues = rhi_signal_fence_values,
-        .signalFenceCount = 1,
+        .commandBuffers = rhi_command_buffers.data(),
+        .commandBufferCount = narrow_cast<uint32_t>(rhi_command_buffers.size()),
+        .waitFences = rhi_wait_fences.data(),
+        .waitFenceValues = rhi_wait_fence_values.data(),
+        .waitFenceCount = narrow_cast<uint32_t>(rhi_wait_fences.size()),
+        .signalFences = rhi_signal_fences.data(),
+        .signalFenceValues = rhi_signal_fence_values.data(),
+        .signalFenceCount = narrow_cast<uint32_t>(rhi_signal_fences.size()),
     };
-    m_rhi_graphics_queue->submit(rhi_submit_desc);
+    SLANG_CALL(m_rhi_graphics_queue->submit(rhi_submit_desc));
     m_wait_global_fence = false;
 
-    if (m_supports_cuda_interop && command_buffer->m_cuda_interop_buffers.size() > 0) {
+    // Handle CUDA interop.
+    if (m_supports_cuda_interop && needs_cuda_sync) {
         sync_to_device(cuda_stream);
 
-        for (const auto& buffer : command_buffer->m_cuda_interop_buffers)
-            if (buffer->is_uav())
-                buffer->copy_to_cuda(cuda_stream);
+        for (CommandBuffer* command_buffer : command_buffers) {
+            for (const auto& buffer : command_buffer->m_cuda_interop_buffers) {
+                if (buffer->is_uav())
+                    buffer->copy_to_cuda(cuda_stream);
+            }
+        }
     }
 
     return m_global_fence->signaled_value();
+}
+
+uint64_t Device::submit_command_buffer(CommandBuffer* command_buffer, CommandQueueType queue)
+{
+    CommandBuffer* command_buffers[] = {command_buffer};
+    return submit_command_buffers(command_buffers, {}, {}, {}, {}, queue);
 }
 
 bool Device::is_command_buffer_complete(uint64_t id)

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -419,9 +419,37 @@ public:
     ref<CommandEncoder> create_command_encoder(CommandQueueType queue = CommandQueueType::graphics);
 
     /**
+     * \brief Submit a list of command buffers to the device.
+     *
+     * The returned submission ID can be used to wait for the submission to complete.
+     *
+     * The wait fence values are optional. If not provided, the fence values will be set to AUTO, which means waiting
+     * for the last signaled value.
+     *
+     * The signal fence values are optional. If not provided, the fence values will be set to AUTO, which means
+     * incrementing the last signaled value by 1.     *
+     *
+     * \param command_buffers List of command buffers to submit.
+     * \param wait_fences List of fences to wait for before executing the command buffers.
+     * \param wait_fence_values List of fence values to wait for before executing the command buffers.
+     * \param signal_fences List of fences to signal after executing the command buffers.
+     * \param signal_fence_values List of fence values to signal after executing the command buffers.
+     * \param queue Command queue to submit to.
+     * \return Submission ID.
+     */
+    uint64_t submit_command_buffers(
+        std::span<CommandBuffer*> command_buffers,
+        std::span<Fence*> wait_fences = {},
+        std::span<uint64_t> wait_fence_values = {},
+        std::span<Fence*> signal_fences = {},
+        std::span<uint64_t> signal_fence_values = {},
+        CommandQueueType queue = CommandQueueType::graphics
+    );
+
+    /**
      * \brief Submit a command buffer to the device.
      *
-     * The returned submission ID can be used to wait for the command buffer to complete.
+     * The returned submission ID can be used to wait for the submission to complete.
      *
      * \param command_buffer Command buffer to submit.
      * \param queue Command queue to submit to.

--- a/src/sgl/device/device.h
+++ b/src/sgl/device/device.h
@@ -458,19 +458,19 @@ public:
     uint64_t submit_command_buffer(CommandBuffer* command_buffer, CommandQueueType queue = CommandQueueType::graphics);
 
     /**
-     * \brief Check if a command buffer is complete.
+     * \brief Check if a submission is finished executing.
      *
      * \param id Submission ID.
-     * \return True if the command buffer is complete.
+     * \return True if the submission is finished executing.
      */
-    bool is_command_buffer_complete(uint64_t id);
+    bool is_submit_finished(uint64_t id);
 
     /**
-     * \brief Wait for a command buffer to complete.
+     * \brief Wait for a submission to finish execution.
      *
      * \param id Submission ID.
      */
-    void wait_command_buffer(uint64_t id);
+    void wait_for_submit(uint64_t id);
 
     /**
      * \brief Wait for the command queue to be idle.

--- a/src/sgl/device/python/device.cpp
+++ b/src/sgl/device/python/device.cpp
@@ -510,6 +510,17 @@ SGL_PY_EXPORT(device_device)
         D(Device, create_command_encoder)
     );
     device.def(
+        "submit_command_buffers",
+        &Device::submit_command_buffers,
+        "command_buffers"_a,
+        "wait_fences"_a = std::span<Fence*>(),
+        "wait_fence_values"_a = std::span<uint64_t>(),
+        "signal_fences"_a = std::span<Fence*>(),
+        "signal_fence_values"_a = std::span<uint64_t>(),
+        "queue"_a = CommandQueueType::graphics,
+        D(Device, submit_command_buffers)
+    );
+    device.def(
         "submit_command_buffer",
         &Device::submit_command_buffer,
         "command_buffer"_a,

--- a/src/sgl/device/python/device.cpp
+++ b/src/sgl/device/python/device.cpp
@@ -527,13 +527,8 @@ SGL_PY_EXPORT(device_device)
         "queue"_a = CommandQueueType::graphics,
         D(Device, submit_command_buffer)
     );
-    device.def(
-        "is_command_buffer_complete",
-        &Device::is_command_buffer_complete,
-        "id"_a,
-        D(Device, is_command_buffer_complete)
-    );
-    device.def("wait_command_buffer", &Device::wait_command_buffer, "id"_a, D(Device, wait_command_buffer));
+    device.def("is_submit_finished", &Device::is_submit_finished, "id"_a, D(Device, is_submit_finished));
+    device.def("wait_for_submit", &Device::wait_for_submit, "id"_a, D(Device, wait_for_submit));
     device
         .def("wait_for_idle", &Device::wait_for_idle, "queue"_a = CommandQueueType::graphics, D(Device, wait_for_idle));
     device.def(

--- a/src/sgl/python/py_doc.h
+++ b/src/sgl/python/py_doc.h
@@ -2794,6 +2794,8 @@ static const char *__doc_sgl_Device_shader_cache_stats = R"doc(Shader cache stat
 
 static const char *__doc_sgl_Device_slang_session = R"doc(Default slang session.)doc";
 
+static const char *__doc_sgl_Device_submit_command_buffers = R"doc()doc";
+
 static const char *__doc_sgl_Device_submit_command_buffer =
 R"doc(Submit a command buffer to the device.
 

--- a/src/sgl/python/py_doc.h
+++ b/src/sgl/python/py_doc.h
@@ -2679,7 +2679,7 @@ static const char *__doc_sgl_Device_hot_reload = R"doc()doc";
 
 static const char *__doc_sgl_Device_info = R"doc(Device information.)doc";
 
-static const char *__doc_sgl_Device_is_command_buffer_complete =
+static const char *__doc_sgl_Device_is_submit_finished =
 R"doc(Check if a command buffer is complete.
 
 Parameter ``id``:
@@ -2868,7 +2868,7 @@ static const char *__doc_sgl_Device_upload_texture_data_2 = R"doc()doc";
 
 static const char *__doc_sgl_Device_wait = R"doc(Wait for all device work to complete.)doc";
 
-static const char *__doc_sgl_Device_wait_command_buffer =
+static const char *__doc_sgl_Device_wait_for_submit =
 R"doc(Wait for a command buffer to complete.
 
 Parameter ``id``:


### PR DESCRIPTION
- add `Device::submit_command_buffers` that can take multiple buffers and also wait/signal fences
- rename `Device::is_command_buffer_complete` to `is_submit_finished`
- rename `Device::wait_command_buffer` to `wait_for_submit`